### PR TITLE
worker: allow concurrent backend executions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,11 +111,102 @@ jobs:
           cargo pgrx test pg${{ env.PG_MAJOR }} -p pg_test --no-default-features
           cargo llvm-cov report --lcov --output-path pgrx_lcov.info
 
-      - name: Run pg_fusion pgrx smoke tests
+      - name: Run pg_fusion SQL smoke tests
         working-directory: .
         run: |
-          cargo pgrx test pg${{ env.PG_MAJOR }} -p pg_fusion --features pg_test pg_fusion_simple_select_smoke
-          PG_FUSION_SPILL_PG_TEST=1 cargo pgrx test pg${{ env.PG_MAJOR }} -p pg_fusion --features pg_test pg_fusion_spill_metrics_smoke
+          PG_BIN="/usr/lib/postgresql/${{ env.PG_MAJOR }}/bin"
+          PGDATA="$(mktemp -d)"
+          PORT=55432
+
+          cleanup() {
+            "$PG_BIN/pg_ctl" -D "$PGDATA" -m fast -w stop || true
+            rm -rf "$PGDATA"
+          }
+          trap cleanup EXIT
+
+          cargo pgrx install \
+            --pg-config "$PG_BIN/pg_config" \
+            -p pg_fusion \
+            --no-default-features \
+            --features "pg${{ env.PG_MAJOR }} pg_test"
+
+          "$PG_BIN/initdb" -D "$PGDATA" -A trust -U postgres --locale=C --encoding=UTF8
+          cat >> "$PGDATA/postgresql.conf" <<EOF
+          shared_preload_libraries = 'pg_fusion'
+          pg_fusion.worker_memory_limit_mb = 128
+          listen_addresses = '127.0.0.1'
+          port = $PORT
+          unix_socket_directories = '/tmp'
+          EOF
+          "$PG_BIN/pg_ctl" -D "$PGDATA" -l "$PGDATA/postgres.log" -w start || {
+            cat "$PGDATA/postgres.log"
+            exit 1
+          }
+
+          "$PG_BIN/psql" \
+            -h 127.0.0.1 \
+            -p "$PORT" \
+            -U postgres \
+            -d postgres \
+            -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE EXTENSION pg_fusion;
+
+          SELECT 1 / CASE
+            WHEN current_setting('shared_preload_libraries') = 'pg_fusion'
+            THEN 1 ELSE 0
+          END AS shared_preload_ok;
+
+          SET pg_fusion.enable = on;
+          SELECT 1 / CASE WHEN (SELECT 1::bigint) = 1 THEN 1 ELSE 0 END AS simple_select_ok;
+
+          BEGIN;
+          SET LOCAL pg_fusion.enable = off;
+          CREATE TEMP TABLE pgf_spill_metrics_smoke AS
+            SELECT g::int AS k, repeat(md5(g::text), 8) AS payload
+            FROM generate_series(1, 200000) AS g;
+          SET LOCAL pg_fusion.enable = on;
+          CREATE TEMP TABLE pgf_spill_epoch AS
+            SELECT pg_fusion_metrics_reset() AS epoch;
+
+          SELECT 1 / CASE
+            WHEN (
+              SELECT max(rn)::bigint
+              FROM (
+                SELECT row_number() OVER (ORDER BY payload) AS rn
+                FROM pgf_spill_metrics_smoke
+              ) AS ordered_src
+            ) = 200000
+            THEN 1 ELSE 0
+          END AS spill_query_ok;
+
+          WITH summary AS (
+            SELECT
+              coalesce(max(value) FILTER (WHERE metric = 'worker_spill_count_total'), 0) AS spill_count,
+              coalesce(max(value) FILTER (WHERE metric = 'worker_spilled_rows_total'), 0) AS spilled_rows,
+              coalesce(max(value) FILTER (WHERE metric = 'worker_spilled_bytes_total'), 0) AS spilled_bytes,
+              coalesce(max(value) FILTER (WHERE metric = 'worker_spill_dirs_created_total'), 0) AS dirs_created,
+              coalesce(max(value) FILTER (WHERE metric = 'worker_spill_dirs_removed_total'), 0) AS dirs_removed,
+              coalesce(max(value) FILTER (WHERE metric = 'worker_spill_leaked_files_total'), 0) AS leaked_files,
+              coalesce(max(value) FILTER (WHERE metric = 'worker_spill_leaked_bytes_total'), 0) AS leaked_bytes,
+              coalesce(max(value) FILTER (WHERE metric = 'worker_spill_cleanup_errors_total'), 0) AS cleanup_errors,
+              coalesce(max(reset_epoch), 0) AS reset_epoch
+            FROM pg_fusion_metrics()
+          )
+          SELECT 1 / CASE
+            WHEN spill_count > 0
+              AND spilled_rows > 0
+              AND spilled_bytes > 0
+              AND dirs_created > 0
+              AND dirs_removed > 0
+              AND leaked_files = 0
+              AND leaked_bytes = 0
+              AND cleanup_errors = 0
+              AND reset_epoch = (SELECT epoch FROM pgf_spill_epoch)
+            THEN 1 ELSE 0
+          END AS spill_metrics_ok
+          FROM summary;
+          ROLLBACK;
+          SQL
 
       - name: Upload pgrx coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,18 +100,22 @@ jobs:
                            $(/usr/lib/postgresql/${{ env.PG_MAJOR }}/bin/pg_config --sharedir)/extension \
                            /var/run/postgresql/
 
-      - name: Run pgrx coverage tests
+      - name: Run pg_test pgrx coverage tests
         working-directory: .
         run: |
-          # Run PostgreSQL-bound crates with coverage inside pgrx/PostgreSQL.
+          # Run PostgreSQL-bound test crate with coverage inside pgrx/PostgreSQL.
           LLVM_COV_ENV=$(mktemp)
           cargo llvm-cov show-env --export-prefix > "$LLVM_COV_ENV"
           source "$LLVM_COV_ENV"
           cargo llvm-cov clean
           cargo pgrx test pg${{ env.PG_MAJOR }} -p pg_test --no-default-features
+          cargo llvm-cov report --lcov --output-path pgrx_lcov.info
+
+      - name: Run pg_fusion pgrx smoke tests
+        working-directory: .
+        run: |
           cargo pgrx test pg${{ env.PG_MAJOR }} -p pg_fusion --features pg_test pg_fusion_simple_select_smoke
           PG_FUSION_SPILL_PG_TEST=1 cargo pgrx test pg${{ env.PG_MAJOR }} -p pg_fusion --features pg_test pg_fusion_spill_metrics_smoke
-          cargo llvm-cov report --lcov --output-path pgrx_lcov.info
 
       - name: Upload pgrx coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,6 +3209,7 @@ dependencies = [
  "futures",
  "import",
  "issuance",
+ "libc",
  "metrics",
  "pg_frontend",
  "pg_type",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 name = "filter"
 version = "25.0.0"
 dependencies = [
+ "control_transport",
  "criterion",
  "loom",
 ]

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -33,9 +33,12 @@ page-backed Arrow batches.
   reference counts so ready storage is reused only after the owner and all
   probes have exited, preserving the no-false-negative property. Pool slots are
   claimed in an unprobeable initializing state and published only after refs
-  and target metadata are initialized. Filter execution namespaces are derived
-  from `control_transport::BackendLeaseSlot` plus the backend session epoch so
-  worker and backend scan producers use the same primary lease identity.
+  and target metadata are initialized. Pool slot state, refcount, and
+  publication epoch are packed into one atomic word so delayed probe lookups
+  cannot acquire references against a reused slot incarnation. Filter execution
+  namespaces are derived from `control_transport::BackendLeaseSlot` plus the
+  backend session epoch so worker and backend scan producers use the same
+  primary lease identity.
 - `page/pool`, `page/transfer`, `page/issuance`: fixed-page ownership,
   transfer, and issued-frame flow.
 - `runtime/metrics`: shared-memory runtime counters and page-slot handoff

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -3,7 +3,7 @@ id: arch-overview-0001
 type: fact
 scope: repo
 tags: ["architecture", "datafusion", "pgrx", "shared-memory", "ipc", "slot_scan", "statistics"]
-updated_at: "2026-05-31"
+updated_at: "2026-06-25"
 importance: 0.8
 ---
 
@@ -31,7 +31,11 @@ page-backed Arrow batches.
   with a CAS, and probes only reject rows for a matching ready generation.
   Stale or in-progress generations pass rows unfiltered. Pool slots use
   reference counts so ready storage is reused only after the owner and all
-  probes have exited, preserving the no-false-negative property.
+  probes have exited, preserving the no-false-negative property. Pool slots are
+  claimed in an unprobeable initializing state and published only after refs
+  and target metadata are initialized. Filter execution namespaces are derived
+  from `control_transport::BackendLeaseSlot` plus the backend session epoch so
+  worker and backend scan producers use the same primary lease identity.
 - `page/pool`, `page/transfer`, `page/issuance`: fixed-page ownership,
   transfer, and issued-frame flow.
 - `runtime/metrics`: shared-memory runtime counters and page-slot handoff
@@ -149,10 +153,12 @@ page-backed Arrow batches.
    `text`/`varchar`/`bpchar`/`name`), and a `WorkerPgScanExec` on the
    probe side, possibly below DataFusion's
    schema-preserving `CooperativeExec` wrapper. The worker registers the target
-   by `(session_epoch,
-   scan_id, output_column)` in shared memory, fills the filter while consuming
-   the build side, and publishes it when that stream reaches EOF. If the pool
-   is full the join runs unchanged and increments a diagnostic counter.
+   by the primary backend lease identity plus session epoch, scan id, and
+   output column in shared memory, fills the filter while consuming the build
+   side, and publishes it when that stream reaches EOF. Backend scan producers,
+   including dynamic standalone scan workers, attach with the same execution
+   namespace so concurrently running backends cannot share filter targets. If
+   the pool is full the join runs unchanged and increments a diagnostic counter.
 3. Worker DataFusion execution opens scans through the runtime protocol.
 4. Backend executes trusted scan SQL through `slot_scan`, drains PostgreSQL
    executor slots with a custom `DestReceiver` and explicit fetch row budgets,

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -186,7 +186,7 @@ page-backed Arrow batches.
    Tokio tasks only drive DataFusion planning, multi-partition root collection,
    and result-stream polling.
    If `pg_fusion.worker_memory_limit_mb` is positive, execution uses a
-   worker-owned DataFusion `RuntimeEnv` with a finite memory pool and
+   worker-owned finite memory pool shared by concurrent worker tasks plus a
    per-execution OS spill directory below a cluster-scoped worker spill root.
    The worker garbage-collects pg_fusion-marked stale spill directories in that
    cluster namespace at generation startup; disabled spill does not create

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -167,18 +167,24 @@ page-backed Arrow batches.
    each producer owns a dedicated scan control slot and writes its own Arrow
    pages into shared memory.
 5. Worker imports scan pages as Arrow `RecordBatch` values, runs DataFusion
-   operators under its Tokio runtime, writes Arrow result pages, and sends
-   issued frames back. `pg_fusion.worker_threads` controls the Tokio runtime
-   thread count, but worker physical planning still sets DataFusion
-   `target_partitions = 1`; changing scan/physical partitioning is a separate
-   execution-model change. Zero-row plans whose DataFusion stream has an
+   operators under per-backend Tokio tasks, writes Arrow result pages, and asks
+   the worker scheduler thread to send issued frames back. Tokio task events
+   wake the scheduler through a local nonblocking Unix socket that the
+   PostgreSQL background-worker thread waits on alongside its PG latch. That
+   thread remains the only owner of PG latch/signal polling and primary control
+   transport. `pg_fusion.worker_threads` controls the Tokio runtime thread
+   count; `pg_fusion.max_fusion_tasks` limits concurrent backend execution
+   tasks and defaults to the primary control slot count.
+   Worker physical planning still sets DataFusion `target_partitions = 1`;
+   changing scan/physical partitioning is a separate execution-model change.
+   Zero-row plans whose DataFusion stream has an
    empty schema, such as `EmptyExec`, use a close-only result path with no Arrow
    pages. Row-count-only PostgreSQL scans use dummy SQL projection in
    PostgreSQL but transfer non-empty empty-schema Arrow pages; these scans stay
    leader-only because dynamic scan workers require projected base-relation
    columns. Scan production remains on PostgreSQL backend/scan-worker threads;
-   Tokio only drives DataFusion planning, multi-partition root collection, and
-   result-stream polling.
+   Tokio tasks only drive DataFusion planning, multi-partition root collection,
+   and result-stream polling.
    If `pg_fusion.worker_memory_limit_mb` is positive, execution uses a
    worker-owned DataFusion `RuntimeEnv` with a finite memory pool and
    per-execution OS spill directory below a cluster-scoped worker spill root.

--- a/ai/components/host_runtime.md
+++ b/ai/components/host_runtime.md
@@ -44,8 +44,9 @@ importance: 0.8
   PostgreSQL APIs from Tokio tasks.
 - Worker-side DataFusion spill is opt-in through Postmaster GUC
   `pg_fusion.worker_memory_limit_mb`. `0` preserves the default unbounded
-  DataFusion runtime; positive values use a finite `FairSpillPool` and
-  per-execution OS temp directories under a cluster-scoped worker spill root.
+  DataFusion runtime; positive values use one finite `FairSpillPool` shared by
+  concurrent worker tasks and per-execution OS temp directories under a
+  cluster-scoped worker spill root.
   The primary worker marks owned worker-incarnation directories, removes stale
   marked directories in the same cluster namespace on startup, and removes
   execution directories on success, failure, or cancel. Disabled spill does not

--- a/ai/components/host_runtime.md
+++ b/ai/components/host_runtime.md
@@ -17,6 +17,17 @@ importance: 0.8
   host keeps unsent scan pages and terminal scan frames pending and retries the
   same frame later; `IssuedOutboundPage::mark_sent()` only follows successful
   carrier delivery.
+- Backend execution admission reserves a worker slot before
+  `StartExecution` and before any dynamic standalone scan workers are launched.
+  Active executions plus granted-but-not-yet-started reservations count against
+  `pg_fusion.max_fusion_tasks`; queued reservation requests do not. This keeps
+  the task cap from leaving dynamic scan workers waiting for `OpenScan` behind
+  an unread backend control ring. The reservation queue is FIFO: once any
+  backend is queued, later requests must queue behind it instead of taking newly
+  freed capacity directly. `CancelExecutionReservation` only releases
+  admission before `StartExecution`; while active it is a peer-scoped protocol
+  failure reported through `FailExecution`, and once retained it is stale
+  traffic that must not discard pending terminal delivery.
 - PostgreSQL `max_parallel_workers_per_gather` controls the query-wide dynamic
   background-worker scan producer budget for eligible heap scans. Each scan
   always has a leader backend producer; positive budget is shared across scans,
@@ -35,13 +46,32 @@ importance: 0.8
   own control transport or PostgreSQL APIs. `pg_fusion.worker_threads` controls
   the runtime thread count (`0` chooses from available CPU parallelism), and
   `pg_fusion.max_fusion_tasks` limits concurrent backend execution tasks (`0`
-  defaults to the primary control slot count). Worker physical planning still
-  fixes DataFusion `target_partitions` at `1`. Root physical plans are driven
-  through DataFusion `execute_stream`, so multi-partition roots such as `UNION`
-  are collected by DataFusion rather than by manually executing only partition
-  `0`. PostgreSQL scan producers remain ordinary backend/scan-worker threads:
-  they communicate through shared-memory scan transport and never call
-  PostgreSQL APIs from Tokio tasks.
+  defaults to the primary control slot count). After terminal cleanup, the
+  scheduler can retain an idle per-peer runtime entry until the backend lease
+  detaches; that retained state does not count against `max_fusion_tasks` and
+  exists only to classify duplicate or late terminal control frames as stale;
+  retention is bounded by physical primary slot id and replaced on slot reuse.
+  Scheduler routing checks active, reserved, and retained peers before
+  admission, so late session-scoped controls for retained peers are decoded by
+  the runtime instead of by the pre-session reservation parser.
+  Late Tokio task events are also matched against the active execution session
+  before the scheduler sends result or terminal frames, so stale task output is
+  contained to the obsolete execution instead of failing the primary worker.
+  Worker-side planning and execution failures are reported as
+  `FailExecution` to the owning backend. If the worker-to-backend terminal
+  control ring is full, the scheduler keeps that terminal control on the
+  retained execution and retries it without counting the cleaned execution
+  against `pg_fusion.max_fusion_tasks`; detached peers clear the pending
+  terminal, while corrupt/global transport errors remain worker-fatal.
+  The primary worker transport scratch buffer is sized for the larger of the
+  backend-to-worker and worker-to-backend primary control capacities because it
+  is reused for both inbound decode and outbound terminal encode.
+  Worker physical planning still fixes DataFusion `target_partitions` at `1`.
+  Root physical plans are driven through DataFusion `execute_stream`, so
+  multi-partition roots such as `UNION` are collected by DataFusion rather than
+  by manually executing only partition `0`. PostgreSQL scan producers remain
+  ordinary backend/scan-worker threads: they communicate through shared-memory
+  scan transport and never call PostgreSQL APIs from Tokio tasks.
 - Worker-side DataFusion spill is opt-in through Postmaster GUC
   `pg_fusion.worker_memory_limit_mb`. `0` preserves the default unbounded
   DataFusion runtime; positive values use one finite `FairSpillPool` shared by

--- a/ai/components/host_runtime.md
+++ b/ai/components/host_runtime.md
@@ -3,7 +3,7 @@ id: comp-host-runtime-0001
 type: fact
 scope: host_runtime
 tags: ["pgrx", "datafusion", "shared-memory", "protocol", "slot_scan"]
-updated_at: "2026-05-11"
+updated_at: "2026-06-25"
 importance: 0.8
 ---
 
@@ -69,14 +69,14 @@ importance: 0.8
   (default `on`) plus postmaster-sized pool settings
   `pg_fusion.runtime_filter_count`, `pg_fusion.runtime_filter_bits`, and
   `pg_fusion.runtime_filter_hashes`. Worker physical planning allocates filters
-  from a shared-memory pool and records `(session_epoch, scan_id,
-  output_column, key_type)` metadata there. Backend scan producers, including
-  dynamic standalone scan workers, attach probes by `(session_epoch, scan_id)`
-  at scan open and test supported bool, integer, float, uuid, binary, and
+  from a shared-memory pool and records metadata keyed by `RuntimeFilterExecId`
+  (primary control slot id, generation, lease epoch, session epoch), scan id,
+  output column, and key type. Backend scan producers, including dynamic
+  standalone scan workers, attach probes by `(RuntimeFilterExecId, scan_id)` at
+  scan open and test supported bool, integer, float, uuid, binary, and
   text-like keys before Arrow encoding. No control-ring message is needed for
-  readiness;
-  probes read the shared lifecycle word and pass rows unfiltered until the
-  matching generation is `Ready`.
+  readiness; probes read the shared lifecycle word and pass rows unfiltered
+  until the matching generation is `Ready`.
 - Results return as issued Arrow pages and are projected into PostgreSQL tuple
   slots through `pg/slot_import`.
 - Worker-originated execution failures send a bounded UTF-8 detail string in

--- a/ai/components/host_runtime.md
+++ b/ai/components/host_runtime.md
@@ -30,14 +30,18 @@ importance: 0.8
   continue leader-only for the current and remaining scans; readiness/protocol
   failures still fail the query.
 - The primary worker owns a Tokio runtime for DataFusion physical planning and
-  result-stream execution. `pg_fusion.worker_threads` controls that runtime's
-  thread count (`0` chooses from available CPU parallelism), while worker
-  physical planning still fixes DataFusion `target_partitions` at `1`. Root
-  physical plans are driven through DataFusion `execute_stream`, so
-  multi-partition roots such as `UNION` are collected by DataFusion rather than
-  by manually executing only partition `0`. PostgreSQL scan producers remain
-  ordinary backend/scan-worker threads: they communicate through shared-memory
-  scan transport and never call PostgreSQL APIs from Tokio tasks.
+  result-stream execution. The PostgreSQL background-worker thread remains the
+  transport scheduler and PG latch/signal integration point; Tokio tasks do not
+  own control transport or PostgreSQL APIs. `pg_fusion.worker_threads` controls
+  the runtime thread count (`0` chooses from available CPU parallelism), and
+  `pg_fusion.max_fusion_tasks` limits concurrent backend execution tasks (`0`
+  defaults to the primary control slot count). Worker physical planning still
+  fixes DataFusion `target_partitions` at `1`. Root physical plans are driven
+  through DataFusion `execute_stream`, so multi-partition roots such as `UNION`
+  are collected by DataFusion rather than by manually executing only partition
+  `0`. PostgreSQL scan producers remain ordinary backend/scan-worker threads:
+  they communicate through shared-memory scan transport and never call
+  PostgreSQL APIs from Tokio tasks.
 - Worker-side DataFusion spill is opt-in through Postmaster GUC
   `pg_fusion.worker_memory_limit_mb`. `0` preserves the default unbounded
   DataFusion runtime; positive values use a finite `FairSpillPool` and

--- a/ai/gotchas.md
+++ b/ai/gotchas.md
@@ -93,9 +93,15 @@ importance: 0.7
   ...)` directly only drains partition `0` and breaks multi-partition roots
   such as `UNION`.
 - `pg_fusion.worker_threads` controls the worker's Tokio runtime thread count.
-  It does not make `WorkerPgScanExec` multi-partition and does not change the
-  current worker planning contract of `target_partitions = 1`; scan/physical
-  partitioning changes must be designed separately.
+  It does not make `WorkerPgScanExec` multi-partition, does not change the
+  current worker planning contract of `target_partitions = 1`, and is separate
+  from `pg_fusion.max_fusion_tasks`, which caps concurrent backend execution
+  tasks. Scan/physical partitioning changes must be designed separately.
+- Worker Tokio tasks must not call PostgreSQL APIs or write primary control
+  transport directly. They report planning, result-page, close-frame, and
+  terminal events back to the PostgreSQL background-worker scheduler thread,
+  then wake it through the local scheduler wake fd that is waited together with
+  the PG latch.
 - Worker DataFusion spill is OS-path spill owned by pg_fusion. It is enabled
   only when `pg_fusion.worker_memory_limit_mb > 0`, creates per-execution
   directories below a cluster-scoped worker spill root, and relies on worker

--- a/ai/gotchas.md
+++ b/ai/gotchas.md
@@ -25,9 +25,11 @@ importance: 0.7
 - `slot_scan` should execute trusted compiler-generated scan SQL. SQL safety and
   expression pushdown policy belong in `scan_sql`.
 - PostgreSQL-bound crates should not be included in standalone `cargo test` or
-  library coverage: they reference PostgreSQL backend symbols. Keep their
-  coverage in pgrx tests (`cargo pgrx test pg17 -p pg_test` and
-  `cargo pgrx test pg17 -p pg_fusion --features pg_test`).
+  library coverage: they reference PostgreSQL backend symbols. `pg_test` can
+  run under `cargo llvm-cov` through pgrx, but `pg_fusion` extension smoke
+  tests should run as plain `cargo pgrx test`; coverage flags retain dead
+  PostgreSQL extern references that the pgrx test harness expects the Linux
+  linker to discard.
 - The committed `pg_compat` corpus under `pg/extension/pg_compat` is a
   differential pgrx test, not upstream `pg_regress`: fixtures are local,
   `passed.sql` cases must use `Custom Scan (PgFusionScan)`, and results are

--- a/ai/gotchas.md
+++ b/ai/gotchas.md
@@ -27,9 +27,10 @@ importance: 0.7
 - PostgreSQL-bound crates should not be included in standalone `cargo test` or
   library coverage: they reference PostgreSQL backend symbols. `pg_test` can
   run under `cargo llvm-cov` through pgrx, but `pg_fusion` extension smoke
-  tests should run as plain `cargo pgrx test`; coverage flags retain dead
-  PostgreSQL extern references that the pgrx test harness expects the Linux
-  linker to discard.
+  coverage should not use `cargo pgrx test -p pg_fusion` on Linux; its Rust
+  test harness can retain PostgreSQL extern references. CI should install the
+  extension into a temporary PostgreSQL cluster and run SQL smoke assertions
+  instead.
 - The committed `pg_compat` corpus under `pg/extension/pg_compat` is a
   differential pgrx test, not upstream `pg_regress`: fixtures are local,
   `passed.sql` cases must use `Custom Scan (PgFusionScan)`, and results are

--- a/ai/gotchas.md
+++ b/ai/gotchas.md
@@ -79,11 +79,21 @@ importance: 0.7
   later queries fail with `control worker generation is not active`. The worker
   must probe its active backend peer even when `next_ready_backend_lease` has
   not reported it; backend cleanup can release/finalize the slot without
-  leaving another frame to mark the peer ready.
+  leaving another frame to mark the peer ready. Retained peers must also route
+  through runtime polling before admission parsing, because late
+  session-scoped cancel/fail frames are stale controls, not malformed
+  pre-session reservation traffic.
 - Dynamic standalone scan workers must keep polling their scan control ring
   after `OpenScan`. `CancelScan` is the worker-side signal that releases those
   PostgreSQL backends and their relation locks when another producer fails or
   the result stream is dropped.
+- `pg_fusion.max_fusion_tasks` must throttle at execution admission, not by
+  ignoring ready backend slots. The backend reserves a worker execution slot
+  before launching dynamic standalone scan workers; if the worker leaves
+  `StartExecution` unread behind the task cap, those producers can time out
+  waiting for `OpenScan` and turn throttling into query failure. Once a
+  reservation request is queued, its frame has already been consumed, so newly
+  ready backend slots must not receive grants ahead of that FIFO queue.
 - `plan_builder` validates subquery shapes after DataFusion logical
   optimization. Subqueries that decorrelate into ordinary relational operators
   can lower PostgreSQL leaf scans; subquery nodes that survive optimization

--- a/benches/tpch/README.md
+++ b/benches/tpch/README.md
@@ -55,6 +55,7 @@ A practical bounded-memory profile for SF1 and smaller diagnostic runs on a
 shared_preload_libraries = 'pg_fusion'
 
 pg_fusion.worker_threads = 0
+pg_fusion.max_fusion_tasks = 0
 pg_fusion.worker_memory_limit_mb = 2048
 pg_fusion.worker_spill_directory = '/tmp/pg_fusion_spill'
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,10 +95,12 @@ The intended operational model is a resource box.
 
 This is different from putting a separate DataFusion runtime in each backend.
 Many backends can feed work into the same cooperative DataFusion/Tokio runtime,
-and the worker can reuse its configured threads across submitted executions. At
-the same time, memory, spill, and shared-memory capacity are easier to reason
-about because they are configured as one worker plus one preallocated transport
-area.
+and the worker can reuse its configured threads across submitted executions.
+The worker's PostgreSQL background-worker thread still owns primary transport
+and PG latch/signal integration; physical planning and execution run as
+per-backend Tokio tasks capped by `pg_fusion.max_fusion_tasks`. At the same
+time, memory, spill, and shared-memory capacity are easier to reason about
+because they are configured as one worker plus one preallocated transport area.
 
 The page pool bounds scan memory behavior. If scan pages or scan channels are
 exhausted, execution applies backpressure instead of allocating an unbounded

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,8 +51,9 @@ The worker is the DataFusion resource box. These settings are postmaster-level.
 | `pg_fusion.log_path` | `/tmp/pg_fusion.log` | Worker diagnostic log path. |
 
 Set `pg_fusion.worker_memory_limit_mb` above `0` only when you want a finite
-DataFusion memory pool and worker-owned spill. Spill files are not PostgreSQL
-temporary files.
+DataFusion memory pool and worker-owned spill. The memory pool is shared across
+concurrent worker execution tasks; spill directories remain per execution.
+Spill files are not PostgreSQL temporary files.
 
 `pg_fusion.worker_threads` controls the Tokio runtime threads inside the
 pg_fusion worker process. It does not control PostgreSQL dynamic scan workers,
@@ -169,9 +170,10 @@ records a diagnostic counter.
 `pg_fusion.worker_memory_limit_mb = 0` keeps DataFusion on the default
 unbounded runtime and disables worker spill.
 
-Setting it above `0` enables a finite DataFusion memory pool and worker-owned
-OS temporary spill files. `pg_fusion.worker_spill_directory` may point at an
-absolute spill root; empty uses OS temporary storage under `pg_fusion/spill`.
+Setting it above `0` enables a finite worker-wide DataFusion memory pool and
+worker-owned OS temporary spill files. `pg_fusion.worker_spill_directory` may
+point at an absolute spill root; empty uses OS temporary storage under
+`pg_fusion/spill`.
 
 This v1 spill path is owned by the pg_fusion worker. It does not use PostgreSQL
 `temp_tablespaces`, `temp_file_limit`, or `ResourceOwner` cleanup.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,7 @@ The worker is the DataFusion resource box. These settings are postmaster-level.
 | Setting | Default | Description |
 | --- | ---: | --- |
 | `pg_fusion.worker_threads` | `0` | DataFusion Tokio runtime thread count. `0` chooses automatically from available CPU parallelism. |
+| `pg_fusion.max_fusion_tasks` | `0` | Maximum concurrent backend execution tasks inside the worker. `0` uses `pg_fusion.control_slot_count`; explicit values are capped at the control slot count. |
 | `pg_fusion.worker_memory_limit_mb` | `0` | DataFusion worker memory limit. `0` uses the default unbounded runtime and disables worker spill. |
 | `pg_fusion.worker_spill_directory` | `''` | Base directory for worker-owned spill files. Empty uses OS temporary storage. |
 | `pg_fusion.worker_log_filter` | `warn` | Worker tracing filter. |
@@ -56,7 +57,12 @@ temporary files.
 `pg_fusion.worker_threads` controls the Tokio runtime threads inside the
 pg_fusion worker process. It does not control PostgreSQL dynamic scan workers,
 and it does not by itself change DataFusion physical plan partitioning. Set it
-to `1` to force the previous single-thread runtime shape.
+to `1` to run the multi-thread Tokio runtime with one worker thread.
+
+`pg_fusion.max_fusion_tasks` limits how many backend executions the worker can
+have active at once. The default `0` uses the primary control slot count, so one
+backend can normally own one worker task. Lower explicit values can be used to
+serialize or throttle worker execution without resizing shared memory.
 
 ## Size Shared Memory
 

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -108,6 +108,12 @@ the configured worker thread pool. The current worker planning contract still
 sets DataFusion `target_partitions` to `1`, so thread count and physical plan
 partition count are separate controls.
 
+The PostgreSQL background-worker thread remains the scheduler for primary
+control transport, result-frame delivery, and PostgreSQL latch/signal handling.
+Physical planning and execution run as per-backend Tokio tasks. The
+`pg_fusion.max_fusion_tasks` GUC caps how many backend executions can be active
+inside the worker; its default `0` uses the primary control slot count.
+
 PostgreSQL scan producers are not Tokio tasks. They remain PostgreSQL backend or
 background-worker execution paths because they call PostgreSQL APIs. Scan
 control slots coordinate those producer streams, but slots are fixed

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -139,6 +139,8 @@ The pg_fusion worker is one PostgreSQL background worker process that owns a
 DataFusion runtime. Tokio drives DataFusion's async execution and internal
 tasks inside that process. `pg_fusion.worker_threads` controls the Tokio
 runtime threads for this worker, not PostgreSQL scan-producer processes.
+`pg_fusion.max_fusion_tasks` caps concurrent backend execution tasks in that
+runtime and defaults to the primary control slot count.
 
 PostgreSQL scan producers remain PostgreSQL backend or background-worker
 threads/processes. They do not call PostgreSQL APIs from Tokio tasks.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,6 +54,7 @@ For a 16 GiB development machine, add:
 shared_preload_libraries = 'pg_fusion'
 
 pg_fusion.worker_threads = 0
+pg_fusion.max_fusion_tasks = 0
 pg_fusion.log_path = '/tmp/pg_fusion.log'
 pg_fusion.worker_log_filter = 'warn'
 pg_fusion.worker_memory_limit_mb = 2048

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,9 +43,10 @@ cargo pgrx test pg17 -p pg_test
 These tests require the pgrx PostgreSQL 17 environment described in
 [Development](development.md#development-environment).
 
-The `pg_fusion` extension smoke tests are run outside `cargo llvm-cov` in CI.
-Coverage flags retain PostgreSQL extension symbols that the Linux pgrx test
-harness normally lets the linker discard.
+In CI, `pg_fusion` extension smoke coverage runs through SQL against a
+temporary PostgreSQL cluster after `cargo pgrx install`. This avoids building
+the `pg_fusion` Rust test harness on Linux, where PostgreSQL extension symbols
+are not available to the harness linker.
 
 ## Spill Tests
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,6 +43,10 @@ cargo pgrx test pg17 -p pg_test
 These tests require the pgrx PostgreSQL 17 environment described in
 [Development](development.md#development-environment).
 
+The `pg_fusion` extension smoke tests are run outside `cargo llvm-cov` in CI.
+Coverage flags retain PostgreSQL extension symbols that the Linux pgrx test
+harness normally lets the linker discard.
+
 ## Spill Tests
 
 Spill tests require finite worker memory. The smoke test is opt-in:

--- a/join_order/src/lib.rs
+++ b/join_order/src/lib.rs
@@ -308,7 +308,7 @@ impl SearchCtx {
                 max_pairs: self.max_pairs,
             });
         }
-        if self.pairs % TIMEOUT_CHECK_INTERVAL == 0 {
+        if self.pairs.is_multiple_of(TIMEOUT_CHECK_INTERVAL) {
             if let Some(timeout) = self.timeout {
                 if self.started_at.elapsed() >= timeout {
                     return Err(OptimizeError::Timeout { pairs: self.pairs });

--- a/page/pool/src/layout.rs
+++ b/page/pool/src/layout.rs
@@ -75,7 +75,7 @@ pub(crate) fn validate_region(
     expected_size: usize,
 ) -> Result<(), (usize, usize, bool)> {
     let address = base.as_ptr() as usize;
-    if address % expected_align != 0 {
+    if !address.is_multiple_of(expected_align) {
         return Err((expected_align, address, false));
     }
     if len < expected_size {
@@ -94,7 +94,7 @@ fn validate_page_size(page_size: usize) -> Result<(), ConfigError> {
             actual: page_size,
         });
     }
-    if page_size % PAGE_ALIGN != 0 {
+    if !page_size.is_multiple_of(PAGE_ALIGN) {
         return Err(ConfigError::PageSizeNotAligned {
             align: PAGE_ALIGN,
             actual: page_size,

--- a/page/pool/src/pool.rs
+++ b/page/pool/src/pool.rs
@@ -136,7 +136,7 @@ impl PagePool {
                 actual: len,
             });
         }
-        if (base.as_ptr() as usize) % header_align != 0 {
+        if !(base.as_ptr() as usize).is_multiple_of(header_align) {
             return Err(AttachError::BadAlignment {
                 expected: header_align,
                 actual: base.as_ptr() as usize,

--- a/pg/backend_service/README.md
+++ b/pg/backend_service/README.md
@@ -56,7 +56,7 @@ streaming:
   `SET LOCAL` state
 - runtime filter settings are also captured into backend/worker config. Scan
   producers attach probes from the shared runtime-filter pool by
-  `(session_epoch, scan_id)` and apply ready integer-key filters before
+  `(RuntimeFilterExecId, scan_id)` and apply ready filters before
   `slot_encoder` writes the row into an Arrow page
 - public `slot_scan::ScanOptions` stay unchanged; these knobs only affect the
   internal backend-service streaming path

--- a/pg/backend_service/src/lib.rs
+++ b/pg/backend_service/src/lib.rs
@@ -12,7 +12,7 @@ use control_transport::{
 };
 use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion_expr::logical_plan::LogicalPlan;
-use filter::RuntimeFilterPool;
+use filter::{RuntimeFilterExecId, RuntimeFilterPool};
 use fsm::backend_execution_flow::StateMachine as BackendExecutionMachine;
 pub use fsm::{BackendExecutionAction, BackendExecutionEvent, BackendExecutionState};
 use issuance::{encode_issued_frame, IssuedTx};
@@ -189,7 +189,7 @@ impl Drop for ExecutionSnapshot {
 }
 
 pub struct StartExecutionInput<'a> {
-    pub slot_id: u32,
+    pub primary_peer: BackendLeaseSlot,
     pub plan_source: ExecutionPlanSource<'a>,
     pub plan_tx: IssuedTx,
     pub scan_slot_region: &'a TransportRegion,
@@ -198,7 +198,7 @@ pub struct StartExecutionInput<'a> {
 }
 
 pub struct StartPreparedExecutionInput<'a> {
-    pub slot_id: u32,
+    pub primary_peer: BackendLeaseSlot,
     pub plan: PreparedExecutionPlan,
     pub plan_tx: IssuedTx,
     pub scan_slot_region: &'a TransportRegion,
@@ -247,6 +247,7 @@ pub struct ScanWorkerQueryInput<'a> {
 
 pub struct ScanWorkerLaunchInput<'a> {
     pub session_epoch: u64,
+    pub runtime_filter_exec_id: RuntimeFilterExecId,
     pub scan_id: u64,
     pub spec: &'a PgScanSpec,
     pub leader_peer: BackendLeaseSlot,
@@ -333,6 +334,7 @@ pub struct StandaloneScanDescriptor {
 pub struct StandaloneScanProducerInput {
     pub descriptor: StandaloneScanDescriptor,
     pub session_epoch: u64,
+    pub runtime_filter_exec_id: RuntimeFilterExecId,
     pub scan_id: u64,
     pub producer_id: u16,
     pub producer_count: u16,
@@ -590,6 +592,7 @@ fn output_schema_from_logical_plan(logical_plan: &LogicalPlan) -> SchemaRef {
 
 struct ActiveExecution {
     key: ExecutionKey,
+    runtime_filter_exec_id: RuntimeFilterExecId,
     snapshot: ExecutionSnapshot,
     _logical_plan: LogicalPlan,
     machine: BackendExecutionMachine,
@@ -829,7 +832,7 @@ impl BackendService {
             config: input.config.clone(),
         })?;
         Self::begin_prepared_execution(StartPreparedExecutionInput {
-            slot_id: input.slot_id,
+            primary_peer: input.primary_peer,
             plan: prepared,
             plan_tx: input.plan_tx,
             scan_slot_region: input.scan_slot_region,
@@ -850,9 +853,11 @@ impl BackendService {
 
             let session_epoch = bump_current_session_epoch();
             let key = ExecutionKey {
-                slot_id: input.slot_id,
+                slot_id: input.primary_peer.slot_id(),
                 session_epoch,
             };
+            let runtime_filter_exec_id =
+                make_runtime_filter_exec_id(input.primary_peer, session_epoch);
 
             let PreparedExecutionPlan {
                 logical_plan,
@@ -905,6 +910,7 @@ impl BackendService {
                 if let Some(launcher) = scan_worker_launcher.as_deref_mut() {
                     let mut output = launcher.launch_scan_workers(ScanWorkerLaunchInput {
                         session_epoch,
+                        runtime_filter_exec_id,
                         scan_id,
                         spec: spec.as_ref(),
                         leader_peer: scan_peer,
@@ -963,6 +969,7 @@ impl BackendService {
 
             *slot.borrow_mut() = Some(ActiveExecution {
                 key,
+                runtime_filter_exec_id,
                 snapshot,
                 _logical_plan: logical_plan,
                 machine,
@@ -1164,7 +1171,7 @@ impl BackendService {
                 metrics: execution.config.metrics,
                 runtime_filter_enabled: execution.config.runtime_filter_enabled,
                 runtime_filters: execution.config.runtime_filters,
-                session_epoch: input.session_epoch,
+                runtime_filter_exec_id: execution.runtime_filter_exec_id,
                 scan_id: input.scan_id,
             });
 
@@ -1395,6 +1402,7 @@ impl BackendService {
                     slot_id,
                     session_epoch,
                 },
+                runtime_filter_exec_id: RuntimeFilterExecId::new(slot_id, 0, 0, session_epoch),
                 snapshot: ExecutionSnapshot::unregistered_for_tests(),
                 _logical_plan: datafusion_expr::logical_plan::LogicalPlan::EmptyRelation(
                     datafusion_expr::logical_plan::EmptyRelation {
@@ -1428,6 +1436,7 @@ impl BackendService {
                     slot_id,
                     session_epoch,
                 },
+                runtime_filter_exec_id: RuntimeFilterExecId::new(slot_id, 0, 0, session_epoch),
                 snapshot: ExecutionSnapshot::unregistered_for_tests(),
                 _logical_plan: datafusion_expr::logical_plan::LogicalPlan::EmptyRelation(
                     datafusion_expr::logical_plan::EmptyRelation {
@@ -1479,6 +1488,10 @@ fn bump_current_session_epoch() -> u64 {
         epoch.set(next);
         next
     })
+}
+
+fn make_runtime_filter_exec_id(peer: BackendLeaseSlot, session_epoch: u64) -> RuntimeFilterExecId {
+    RuntimeFilterExecId::from_peer(peer, session_epoch)
 }
 
 fn wait_for_scan_backpressure(
@@ -1972,7 +1985,7 @@ fn run_standalone_scan_producer(
     )?;
 
     let source = match standalone_page_source(
-        input.session_epoch,
+        input.runtime_filter_exec_id,
         input.scan_id,
         input.scan_tx.payload_capacity(),
         &input.config,
@@ -2013,7 +2026,7 @@ fn run_standalone_scan_producer(
 }
 
 fn standalone_page_source(
-    session_epoch: u64,
+    runtime_filter_exec_id: RuntimeFilterExecId,
     scan_id: u64,
     payload_capacity: usize,
     config: &BackendServiceConfig,
@@ -2081,7 +2094,7 @@ fn standalone_page_source(
             metrics: config.metrics,
             runtime_filter_enabled: config.runtime_filter_enabled,
             runtime_filters: config.runtime_filters,
-            session_epoch,
+            runtime_filter_exec_id,
             scan_id,
         },
     ))
@@ -2964,6 +2977,7 @@ fn cleanup_execution(
 
     let ActiveExecution {
         key,
+        runtime_filter_exec_id: _,
         snapshot,
         _logical_plan,
         machine: _machine,

--- a/pg/backend_service/src/source.rs
+++ b/pg/backend_service/src/source.rs
@@ -3,8 +3,8 @@ use arrow_layout::{init_block, LayoutPlan};
 use arrow_schema::SchemaRef;
 use filter::{
     hash_bool_key, hash_bytes_key, hash_decimal128_key, hash_float32_key, hash_float64_key,
-    hash_int_key, hash_interval_month_day_nano_key, ProbeDecision, RuntimeFilterKeyType,
-    RuntimeFilterPool, RuntimeFilterProbeHandle,
+    hash_int_key, hash_interval_month_day_nano_key, ProbeDecision, RuntimeFilterExecId,
+    RuntimeFilterKeyType, RuntimeFilterPool, RuntimeFilterProbeHandle,
 };
 use metrics::{MetricId, RuntimeMetrics};
 use pgrx::pg_sys;
@@ -29,7 +29,7 @@ pub(crate) struct SlotScanPageSource {
     metrics: RuntimeMetrics,
     runtime_filter_enabled: bool,
     runtime_filters: RuntimeFilterPool,
-    session_epoch: u64,
+    runtime_filter_exec_id: RuntimeFilterExecId,
     scan_id: u64,
     runtime_filter_probes: Vec<RuntimeFilterProbeHandle>,
     runtime_filter_needed_attrs: i32,
@@ -50,7 +50,7 @@ pub(crate) struct SlotScanPageSourceInput {
     pub(crate) metrics: RuntimeMetrics,
     pub(crate) runtime_filter_enabled: bool,
     pub(crate) runtime_filters: RuntimeFilterPool,
-    pub(crate) session_epoch: u64,
+    pub(crate) runtime_filter_exec_id: RuntimeFilterExecId,
     pub(crate) scan_id: u64,
 }
 
@@ -68,7 +68,7 @@ impl SlotScanPageSource {
             metrics,
             runtime_filter_enabled,
             runtime_filters,
-            session_epoch,
+            runtime_filter_exec_id,
             scan_id,
         } = input;
         let single_row_drains = estimator
@@ -87,7 +87,7 @@ impl SlotScanPageSource {
             metrics,
             runtime_filter_enabled,
             runtime_filters,
-            session_epoch,
+            runtime_filter_exec_id,
             scan_id,
             runtime_filter_probes: Vec::new(),
             runtime_filter_needed_attrs: 0,
@@ -105,7 +105,7 @@ impl SlotScanPageSource {
         }
 
         self.runtime_filters.lookup_probes(
-            self.session_epoch,
+            self.runtime_filter_exec_id,
             self.scan_id,
             &mut self.runtime_filter_probes,
         );

--- a/pg/df_functions/src/pg_regex.rs
+++ b/pg/df_functions/src/pg_regex.rs
@@ -172,7 +172,7 @@ fn match_regex_arrays(op: PgRegexOp, values: &ArrayRef, patterns: &ArrayRef) -> 
     Ok(Arc::new(builder.finish()))
 }
 
-fn array_text<'a>(array: &'a ArrayRef, row: usize) -> Result<Option<&'a str>> {
+fn array_text(array: &ArrayRef, row: usize) -> Result<Option<&str>> {
     if array.is_null(row) {
         return Ok(None);
     }

--- a/pg/df_functions/src/pg_text_typmod.rs
+++ b/pg/df_functions/src/pg_text_typmod.rs
@@ -350,7 +350,7 @@ fn bpchar_chars(value: &str, length: usize) -> Cow<'_, str> {
             Cow::Owned(output)
         }
     } else {
-        output.extend(std::iter::repeat(' ').take(length - copied));
+        output.extend(std::iter::repeat_n(' ', length - copied));
         Cow::Owned(output)
     }
 }

--- a/pg/extension/Cargo.toml
+++ b/pg/extension/Cargo.toml
@@ -45,3 +45,6 @@ tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 transfer = { path = "../../page/transfer", version = "25.0" }
 worker = { path = "../../runtime/worker", version = "25.0" }
+
+[dev-dependencies]
+libc = "0.2"

--- a/pg/extension/src/custom_scan.rs
+++ b/pg/extension/src/custom_scan.rs
@@ -386,7 +386,7 @@ unsafe fn begin_pg_fusion_scan_impl(
     let (transport_schema, _) = normalize_result_transport_schema(&output_schema)
         .map_err(|err| err.to_string())
         .unwrap_or_else(|err| error!("pg_fusion schema preparation failed: {err}"));
-    let control_lease = BackendSlotLease::acquire(&control_region)
+    let mut control_lease = BackendSlotLease::acquire(&control_region)
         .unwrap_or_else(|err| error!("pg_fusion failed to acquire primary control slot: {err}"));
     host_diag(DiagnosticLogLevel::Basic, || {
         format!(
@@ -394,6 +394,16 @@ unsafe fn begin_pg_fusion_scan_impl(
             control_lease_snapshot(&control_lease),
             host_state_snapshot(state)
         )
+    });
+    let mut primary_scratch = vec![
+        0_u8;
+        config
+            .control_backend_to_worker_capacity
+            .max(config.control_worker_to_backend_capacity)
+    ];
+    reserve_worker_execution_slot(&mut control_lease, &mut primary_scratch).unwrap_or_else(|err| {
+        let _ = cancel_worker_execution_reservation(&mut control_lease, &mut primary_scratch);
+        error!("pg_fusion failed to reserve worker execution slot: {err}");
     });
 
     let plan_tx = IssuedTx::new(PageTx::new(page_pool), issuance_pool);
@@ -413,7 +423,10 @@ unsafe fn begin_pg_fusion_scan_impl(
             scan_worker_launcher: Some(&mut scan_worker_launcher),
         })
     }
-    .unwrap_or_else(|err| error!("pg_fusion begin execution failed: {err}"));
+    .unwrap_or_else(|err| {
+        let _ = cancel_worker_execution_reservation(&mut control_lease, &mut primary_scratch);
+        error!("pg_fusion begin execution failed: {err}");
+    });
     state.execution_key = Some(begin.key);
     host_diag(DiagnosticLogLevel::Basic, || {
         format!(
@@ -425,13 +438,12 @@ unsafe fn begin_pg_fusion_scan_impl(
         )
     });
 
-    let mut control_lease = control_lease;
-    send_backend_execution(&mut control_lease, begin.control(), &mut Vec::new()).unwrap_or_else(
-        |err| {
+    send_backend_execution(&mut control_lease, begin.control(), &mut primary_scratch)
+        .unwrap_or_else(|err| {
+            let _ = cancel_worker_execution_reservation(&mut control_lease, &mut primary_scratch);
             let _ = BackendService::abort_execution_start();
             error!("pg_fusion failed to send StartExecution: {err}");
-        },
-    );
+        });
     publish_plan_to_worker(&mut control_lease).unwrap_or_else(|err| {
         let _ = BackendService::abort_execution_start();
         error!("pg_fusion failed to publish logical plan: {err}");
@@ -464,12 +476,7 @@ unsafe fn begin_pg_fusion_scan_impl(
     state.scan_peers = scan_peers_from_begin(&begin);
     state.scan_channels = begin.scan_channels.to_vec();
     state.pending_complete_session_epoch = None;
-    state.primary_scratch = vec![
-        0_u8;
-        config
-            .control_backend_to_worker_capacity
-            .max(config.control_worker_to_backend_capacity)
-    ];
+    state.primary_scratch = primary_scratch;
     state.scan_scratch = vec![
         0_u8;
         config
@@ -885,6 +892,11 @@ fn handle_primary_control(
         .map(|lease| lease.slot_id())
         .ok_or(BackendServiceError::NoActiveExecution)?;
     match message {
+        WorkerExecutionToBackend::ExecutionSlotReserved => {
+            return Err(BackendServiceError::ProtocolViolation(
+                "received execution reservation grant after execution start".into(),
+            ));
+        }
         WorkerExecutionToBackend::CompleteExecution { session_epoch } => {
             host_diag(DiagnosticLogLevel::Basic, || {
                 format!(
@@ -1459,6 +1471,64 @@ fn send_backend_execution(
     let mut tx = lease.to_worker_tx();
     let _ = tx.send_frame(&scratch[..written])?;
     Ok(())
+}
+
+fn reserve_worker_execution_slot(
+    lease: &mut BackendSlotLease,
+    scratch: &mut Vec<u8>,
+) -> Result<(), BackendServiceError> {
+    reserve_worker_execution_slot_with_wait(lease, scratch, || {
+        wait_latch_checked(Some(Duration::from_millis(1)))
+    })
+}
+
+fn reserve_worker_execution_slot_with_wait(
+    lease: &mut BackendSlotLease,
+    scratch: &mut Vec<u8>,
+    mut wait_for_control_ready: impl FnMut() -> Result<(), BackendServiceError>,
+) -> Result<(), BackendServiceError> {
+    send_backend_execution(
+        lease,
+        BackendExecutionToWorker::ReserveExecutionSlot,
+        scratch,
+    )?;
+    loop {
+        let received = {
+            let mut rx = lease.from_worker_rx();
+            rx.recv_frame_into(scratch)?
+        };
+        if let Some(len) = received {
+            match decode_primary_inbound(&scratch[..len])
+                .map_err(|err| BackendServiceError::ProtocolViolation(err.to_string()))?
+            {
+                PrimaryInbound::Control(WorkerExecutionToBackend::ExecutionSlotReserved) => {
+                    return Ok(());
+                }
+                PrimaryInbound::Control(message) => {
+                    return Err(BackendServiceError::ProtocolViolation(format!(
+                        "received {message:?} while waiting for execution reservation"
+                    )));
+                }
+                PrimaryInbound::Issued(_) => {
+                    return Err(BackendServiceError::ProtocolViolation(
+                        "received result frame while waiting for execution reservation".into(),
+                    ));
+                }
+            }
+        }
+        wait_for_control_ready()?;
+    }
+}
+
+fn cancel_worker_execution_reservation(
+    lease: &mut BackendSlotLease,
+    scratch: &mut Vec<u8>,
+) -> Result<(), BackendServiceError> {
+    send_backend_execution(
+        lease,
+        BackendExecutionToWorker::CancelExecutionReservation,
+        scratch,
+    )
 }
 
 fn decode_primary_inbound(bytes: &[u8]) -> Result<PrimaryInbound, Box<dyn std::error::Error>> {
@@ -2269,6 +2339,102 @@ fn wait_latch(timeout: Option<Duration>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "pg_test")]
+    use std::alloc::{alloc_zeroed, dealloc, Layout};
+    #[cfg(feature = "pg_test")]
+    use std::ptr::NonNull;
+    #[cfg(feature = "pg_test")]
+    use std::sync::Once;
+
+    #[cfg(feature = "pg_test")]
+    use control_transport::{TransportRegion, TransportRegionLayout};
+
+    #[cfg(feature = "pg_test")]
+    struct OwnedRegion {
+        base: NonNull<u8>,
+        layout: Layout,
+    }
+
+    #[cfg(feature = "pg_test")]
+    impl OwnedRegion {
+        fn new(size: usize, align: usize) -> Self {
+            let layout = Layout::from_size_align(size, align).expect("layout");
+            let base = unsafe { alloc_zeroed(layout) };
+            let base = NonNull::new(base).expect("allocation");
+            Self { base, layout }
+        }
+    }
+
+    #[cfg(feature = "pg_test")]
+    impl Drop for OwnedRegion {
+        fn drop(&mut self) {
+            unsafe { dealloc(self.base.as_ptr(), self.layout) };
+        }
+    }
+
+    #[cfg(feature = "pg_test")]
+    fn ignore_sigusr1_for_tests() {
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| unsafe {
+            libc::signal(libc::SIGUSR1, libc::SIG_IGN);
+        });
+    }
+
+    #[cfg(feature = "pg_test")]
+    fn init_control_transport() -> (
+        OwnedRegion,
+        TransportRegion,
+        WorkerTransport,
+        BackendSlotLease,
+    ) {
+        ignore_sigusr1_for_tests();
+        let layout = TransportRegionLayout::new(1, 256, 256).expect("layout");
+        let region_mem = OwnedRegion::new(layout.size, layout.align);
+        let region =
+            unsafe { TransportRegion::init_in_place(region_mem.base, layout.size, layout) }
+                .expect("transport region");
+        let worker = WorkerTransport::attach(&region).expect("attach worker");
+        worker
+            .activate_generation(std::process::id() as i32)
+            .expect("activate generation");
+        let backend = BackendSlotLease::acquire(&region).expect("backend lease");
+        (region_mem, region, worker, backend)
+    }
+
+    #[cfg(feature = "pg_test")]
+    fn send_worker_execution(
+        worker: &WorkerTransport,
+        peer: BackendLeaseSlot,
+        message: WorkerExecutionToBackend,
+    ) {
+        let mut scratch = vec![0_u8; protocol::encoded_len_worker_execution_to_backend(&message)];
+        let written = protocol::encode_worker_execution_to_backend_into(&message, &mut scratch)
+            .expect("encode worker execution");
+        let mut slot = worker
+            .slot_for_backend_lease(peer)
+            .expect("worker slot for backend");
+        let mut tx = slot.to_backend_tx().expect("worker tx");
+        tx.send_frame(&scratch[..written])
+            .expect("send worker frame");
+    }
+
+    #[cfg(feature = "pg_test")]
+    fn recv_backend_execution(
+        worker: &WorkerTransport,
+        peer: BackendLeaseSlot,
+    ) -> protocol::BackendExecutionToWorkerRef<'static> {
+        let mut scratch = vec![0_u8; 256];
+        let mut slot = worker
+            .slot_for_backend_lease(peer)
+            .expect("worker slot for backend");
+        let mut rx = slot.from_backend_rx().expect("worker rx");
+        let len = rx
+            .recv_frame_into(&mut scratch)
+            .expect("receive backend frame")
+            .expect("backend frame");
+        let frame = scratch[..len].to_vec().into_boxed_slice();
+        protocol::decode_backend_execution_to_worker(Box::leak(frame)).expect("decode backend")
+    }
 
     fn candidate(scan_id: u64, block_count: u64, max_workers: u16) -> ScanWorkerBudgetCandidate {
         ScanWorkerBudgetCandidate {
@@ -2284,6 +2450,75 @@ mod tests {
             .get(&scan_id)
             .map(|budget| budget.worker_count)
             .unwrap_or(0)
+    }
+
+    #[cfg(feature = "pg_test")]
+    #[test]
+    fn reserve_worker_execution_slot_uses_ready_grant_without_waiting() {
+        let (_region_mem, _region, worker, mut backend) = init_control_transport();
+        let peer = backend.backend_lease_slot();
+        send_worker_execution(
+            &worker,
+            peer,
+            WorkerExecutionToBackend::ExecutionSlotReserved,
+        );
+        let mut scratch = vec![0_u8; 256];
+        let mut wait_calls = 0;
+
+        reserve_worker_execution_slot_with_wait(&mut backend, &mut scratch, || {
+            wait_calls += 1;
+            Ok(())
+        })
+        .expect("reserve worker slot");
+
+        assert_eq!(
+            recv_backend_execution(&worker, peer),
+            protocol::BackendExecutionToWorkerRef::ReserveExecutionSlot
+        );
+        assert_eq!(wait_calls, 0);
+    }
+
+    #[cfg(feature = "pg_test")]
+    #[test]
+    fn reserve_worker_execution_slot_waits_until_grant_arrives() {
+        let (_region_mem, _region, worker, mut backend) = init_control_transport();
+        let peer = backend.backend_lease_slot();
+        let mut scratch = vec![0_u8; 256];
+        let mut wait_calls = 0;
+
+        reserve_worker_execution_slot_with_wait(&mut backend, &mut scratch, || {
+            wait_calls += 1;
+            assert_eq!(wait_calls, 1);
+            send_worker_execution(
+                &worker,
+                peer,
+                WorkerExecutionToBackend::ExecutionSlotReserved,
+            );
+            Ok(())
+        })
+        .expect("reserve worker slot");
+
+        assert_eq!(
+            recv_backend_execution(&worker, peer),
+            protocol::BackendExecutionToWorkerRef::ReserveExecutionSlot
+        );
+        assert_eq!(wait_calls, 1);
+    }
+
+    #[cfg(feature = "pg_test")]
+    #[test]
+    fn cancel_worker_execution_reservation_sends_cancel_reservation() {
+        let (_region_mem, _region, worker, mut backend) = init_control_transport();
+        let peer = backend.backend_lease_slot();
+        let mut scratch = Vec::new();
+
+        cancel_worker_execution_reservation(&mut backend, &mut scratch)
+            .expect("cancel worker reservation");
+
+        assert_eq!(
+            recv_backend_execution(&worker, peer),
+            protocol::BackendExecutionToWorkerRef::CancelExecutionReservation
+        );
     }
 
     #[test]

--- a/pg/extension/src/custom_scan.rs
+++ b/pg/extension/src/custom_scan.rs
@@ -405,7 +405,7 @@ unsafe fn begin_pg_fusion_scan_impl(
     let begin = {
         let _planner_bypass = PlannerBypassGuard::enter();
         BackendService::begin_prepared_execution(StartPreparedExecutionInput {
-            slot_id: control_lease.slot_id(),
+            primary_peer: control_lease.backend_lease_slot(),
             plan: prepared_plan,
             plan_tx,
             scan_slot_region: &scan_region,
@@ -1571,6 +1571,7 @@ impl ScanWorkerLauncher for DynamicScanWorkerLauncher {
                 db_oid,
                 user_oid,
                 session_epoch: input.session_epoch,
+                runtime_filter_exec_id: input.runtime_filter_exec_id,
                 scan_id: input.scan_id,
                 producer_id,
                 producer_count: total_producers,

--- a/pg/extension/src/guc.rs
+++ b/pg/extension/src/guc.rs
@@ -569,7 +569,7 @@ mod tests {
 
     #[test]
     fn runtime_filter_defaults_to_enabled() {
-        assert!(DEFAULT_RUNTIME_FILTER_ENABLE);
+        const { assert!(DEFAULT_RUNTIME_FILTER_ENABLE) };
     }
 
     #[test]

--- a/pg/extension/src/guc.rs
+++ b/pg/extension/src/guc.rs
@@ -20,6 +20,7 @@ pub(crate) static BACKEND_LOG_LEVEL: GucSetting<i32> = GucSetting::<i32>::new(0)
 pub(crate) static WORKER_MEMORY_LIMIT_MB: GucSetting<i32> = GucSetting::<i32>::new(0);
 pub(crate) static WORKER_SPILL_DIRECTORY: GucSetting<Option<std::ffi::CString>> =
     GucSetting::<Option<std::ffi::CString>>::new(Some(c""));
+pub(crate) static MAX_FUSION_TASKS: GucSetting<i32> = GucSetting::<i32>::new(0);
 
 pub(crate) static CONTROL_SLOT_COUNT: GucSetting<i32> = GucSetting::<i32>::new(64);
 pub(crate) static CONTROL_BACKEND_TO_WORKER_CAPACITY: GucSetting<i32> =
@@ -60,6 +61,7 @@ pub struct HostConfig {
     pub backend_log_level: DiagnosticLogLevel,
     pub worker_memory_limit_bytes: Option<usize>,
     pub worker_spill_directory: Option<PathBuf>,
+    pub max_fusion_tasks: usize,
     pub control_slot_count: u32,
     pub control_backend_to_worker_capacity: usize,
     pub control_worker_to_backend_capacity: usize,
@@ -159,6 +161,16 @@ pub fn register_gucs() {
         c"Worker DataFusion spill directory",
         c"Absolute root directory for worker-owned DataFusion spill files; empty uses the operating system temp directory",
         &WORKER_SPILL_DIRECTORY,
+        GucContext::Postmaster,
+        GucFlags::default(),
+    );
+    GucRegistry::define_int_guc(
+        c"pg_fusion.max_fusion_tasks",
+        c"Maximum concurrent Fusion tasks",
+        c"Maximum concurrent backend executions in the pg_fusion worker; 0 uses pg_fusion.control_slot_count",
+        &MAX_FUSION_TASKS,
+        0,
+        i32::MAX,
         GucContext::Postmaster,
         GucFlags::default(),
     );
@@ -276,6 +288,8 @@ pub fn register_gucs() {
 }
 
 pub fn host_config() -> Result<HostConfig, HostConfigError> {
+    let control_slot_count =
+        positive_u32("pg_fusion.control_slot_count", CONTROL_SLOT_COUNT.get())?;
     let scan_backend_to_worker_capacity = positive_usize(
         "pg_fusion.scan_backend_to_worker_capacity",
         SCAN_BACKEND_TO_WORKER_CAPACITY.get(),
@@ -309,7 +323,8 @@ pub fn host_config() -> Result<HostConfig, HostConfigError> {
             WORKER_MEMORY_LIMIT_MB.get(),
         )?)?,
         worker_spill_directory: worker_spill_directory()?,
-        control_slot_count: positive_u32("pg_fusion.control_slot_count", CONTROL_SLOT_COUNT.get())?,
+        max_fusion_tasks: max_fusion_tasks(MAX_FUSION_TASKS.get(), control_slot_count)?,
+        control_slot_count,
         control_backend_to_worker_capacity: positive_usize(
             "pg_fusion.control_backend_to_worker_capacity",
             CONTROL_BACKEND_TO_WORKER_CAPACITY.get(),
@@ -470,6 +485,16 @@ fn normalize_worker_threads(value: i32) -> Option<usize> {
     }
 }
 
+fn max_fusion_tasks(actual: i32, control_slot_count: u32) -> Result<usize, HostConfigError> {
+    let configured = nonnegative_u32("pg_fusion.max_fusion_tasks", actual)?;
+    let effective = if configured == 0 {
+        control_slot_count
+    } else {
+        configured.min(control_slot_count)
+    };
+    Ok(effective as usize)
+}
+
 fn string_setting(setting: &GucSetting<Option<std::ffi::CString>>, default: &str) -> String {
     setting
         .get()
@@ -555,6 +580,7 @@ mod tests {
             backend_log_level: DiagnosticLogLevel::Trace,
             worker_memory_limit_bytes: Some(128 * 1024 * 1024),
             worker_spill_directory: Some(PathBuf::from("/tmp/pg_fusion_spill")),
+            max_fusion_tasks: 8,
             control_slot_count: 8,
             control_backend_to_worker_capacity: 4096,
             control_worker_to_backend_capacity: 4096,
@@ -602,6 +628,28 @@ mod tests {
         assert_eq!(
             worker_memory_limit_bytes(64).unwrap(),
             Some(64 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn max_fusion_tasks_zero_uses_control_slot_count() {
+        assert_eq!(max_fusion_tasks(0, 64).unwrap(), 64);
+    }
+
+    #[test]
+    fn max_fusion_tasks_clamps_to_control_slot_count() {
+        assert_eq!(max_fusion_tasks(4, 64).unwrap(), 4);
+        assert_eq!(max_fusion_tasks(128, 64).unwrap(), 64);
+    }
+
+    #[test]
+    fn max_fusion_tasks_rejects_negative_values() {
+        assert_eq!(
+            max_fusion_tasks(-1, 64).unwrap_err(),
+            HostConfigError::Negative {
+                name: "pg_fusion.max_fusion_tasks",
+                actual: -1
+            }
         );
     }
 

--- a/pg/extension/src/guc.rs
+++ b/pg/extension/src/guc.rs
@@ -429,7 +429,9 @@ impl HostConfig {
 
     pub fn worker_runtime_config(&self) -> WorkerRuntimeConfig {
         WorkerRuntimeConfig {
-            control_frame_capacity: self.control_backend_to_worker_capacity,
+            control_frame_capacity: self
+                .control_backend_to_worker_capacity
+                .max(self.control_worker_to_backend_capacity),
             spill: WorkerSpillConfig::new(
                 self.worker_memory_limit_bytes,
                 self.worker_spill_directory.clone(),
@@ -582,7 +584,7 @@ mod tests {
             worker_spill_directory: Some(PathBuf::from("/tmp/pg_fusion_spill")),
             max_fusion_tasks: 8,
             control_slot_count: 8,
-            control_backend_to_worker_capacity: 4096,
+            control_backend_to_worker_capacity: 1024,
             control_worker_to_backend_capacity: 4096,
             scan_slot_count: 8,
             scan_backend_to_worker_capacity: MIN_SCAN_BACKEND_TO_WORKER_RING_CAPACITY,

--- a/pg/extension/src/lib.rs
+++ b/pg/extension/src/lib.rs
@@ -21,6 +21,8 @@ mod scan_worker_job;
 mod shmem;
 #[cfg(feature = "pg_test")]
 mod smoke_tests;
+#[cfg(feature = "pg_test")]
+mod test_gate;
 mod utility_hook;
 mod worker;
 
@@ -48,6 +50,29 @@ fn mark_guc_prefix_reserved(guc_prefix: &str) {
 #[pg_schema]
 mod tests {
     use pgrx::prelude::*;
+
+    #[pg_extern]
+    fn pg_fusion_test_execution_gate_reset() -> i32 {
+        super::test_gate::attach().reset();
+        0
+    }
+
+    #[pg_extern]
+    fn pg_fusion_test_execution_gate_release() -> i32 {
+        super::test_gate::attach().release();
+        0
+    }
+
+    #[pg_extern]
+    fn pg_fusion_test_execution_gate_disable() -> i32 {
+        super::test_gate::attach().disable();
+        0
+    }
+
+    #[pg_extern]
+    fn pg_fusion_test_execution_gate_entered() -> i32 {
+        super::test_gate::attach().entered()
+    }
 
     #[pg_test]
     fn pg_fusion_simple_select_smoke() {
@@ -187,6 +212,16 @@ mod tests {
     #[pg_test]
     fn pg_fusion_heap_leader_only_scan_smoke() {
         super::smoke_tests::heap_leader_only_scan_smoke();
+    }
+
+    #[pg_test]
+    fn pg_fusion_worker_concurrent_backend_tasks_smoke() {
+        super::smoke_tests::worker_executes_second_backend_while_first_task_waits_smoke();
+    }
+
+    #[pg_test]
+    fn pg_fusion_multi_page_result_transport_smoke() {
+        super::smoke_tests::multi_page_result_transport_smoke();
     }
 
     #[pg_test]

--- a/pg/extension/src/plan_payload.rs
+++ b/pg/extension/src/plan_payload.rs
@@ -90,7 +90,7 @@ fn hex_encode(bytes: &[u8]) -> String {
 }
 
 fn hex_decode(value: &str) -> Result<Vec<u8>, PlanPayloadError> {
-    if value.len() % 2 != 0 {
+    if !value.len().is_multiple_of(2) {
         return Err(PlanPayloadError::Invalid(
             "hex payload has odd length".into(),
         ));

--- a/pg/extension/src/scan_worker_job.rs
+++ b/pg/extension/src/scan_worker_job.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 
 use backend_service::{StandaloneScanDescriptor, StandaloneScanField};
 use control_transport::{BackendLeaseId, BackendLeaseSlot};
+use filter::RuntimeFilterExecId;
 
 pub(crate) const SCAN_WORKER_JOB_CAPACITY: usize = 64;
 pub(crate) const SCAN_WORKER_PAYLOAD_CAPACITY: usize = 64 * 1024;
@@ -35,6 +36,10 @@ struct ScanWorkerJob {
     db_oid: AtomicU32,
     user_oid: AtomicU32,
     session_epoch: AtomicU64,
+    exec_slot_id: AtomicU32,
+    exec_generation: AtomicU64,
+    exec_lease_epoch: AtomicU64,
+    exec_session_epoch: AtomicU64,
     scan_id: AtomicU64,
     producer_id: AtomicU32,
     producer_count: AtomicU32,
@@ -60,6 +65,7 @@ pub(crate) struct ScanWorkerJobSpec<'a> {
     pub(crate) db_oid: u32,
     pub(crate) user_oid: u32,
     pub(crate) session_epoch: u64,
+    pub(crate) runtime_filter_exec_id: RuntimeFilterExecId,
     pub(crate) scan_id: u64,
     pub(crate) producer_id: u16,
     pub(crate) producer_count: u16,
@@ -71,6 +77,7 @@ pub(crate) struct ScanWorkerJobSnapshot {
     pub(crate) db_oid: u32,
     pub(crate) user_oid: u32,
     pub(crate) session_epoch: u64,
+    pub(crate) runtime_filter_exec_id: RuntimeFilterExecId,
     pub(crate) scan_id: u64,
     pub(crate) producer_id: u16,
     pub(crate) producer_count: u16,
@@ -141,6 +148,7 @@ impl ScanWorkerJobRegistryHandle {
             job.user_oid.store(spec.user_oid, Ordering::Relaxed);
             job.session_epoch
                 .store(spec.session_epoch, Ordering::Relaxed);
+            store_exec_id(job, spec.runtime_filter_exec_id);
             job.scan_id.store(spec.scan_id, Ordering::Relaxed);
             job.producer_id
                 .store(u32::from(spec.producer_id), Ordering::Relaxed);
@@ -185,6 +193,7 @@ impl ScanWorkerJobRegistryHandle {
             db_oid: job.db_oid.load(Ordering::Relaxed),
             user_oid: job.user_oid.load(Ordering::Relaxed),
             session_epoch: job.session_epoch.load(Ordering::Relaxed),
+            runtime_filter_exec_id: load_exec_id(job),
             scan_id: job.scan_id.load(Ordering::Relaxed),
             producer_id: job.producer_id.load(Ordering::Relaxed) as u16,
             producer_count: job.producer_count.load(Ordering::Relaxed) as u16,
@@ -312,6 +321,25 @@ fn try_reserve_job(job: &ScanWorkerJob) -> bool {
         }
     }
     false
+}
+
+fn store_exec_id(job: &ScanWorkerJob, exec_id: RuntimeFilterExecId) {
+    job.exec_slot_id.store(exec_id.slot_id(), Ordering::Relaxed);
+    job.exec_generation
+        .store(exec_id.generation(), Ordering::Relaxed);
+    job.exec_lease_epoch
+        .store(exec_id.lease_epoch(), Ordering::Relaxed);
+    job.exec_session_epoch
+        .store(exec_id.session_epoch(), Ordering::Relaxed);
+}
+
+fn load_exec_id(job: &ScanWorkerJob) -> RuntimeFilterExecId {
+    RuntimeFilterExecId::new(
+        job.exec_slot_id.load(Ordering::Relaxed),
+        job.exec_generation.load(Ordering::Relaxed),
+        job.exec_lease_epoch.load(Ordering::Relaxed),
+        job.exec_session_epoch.load(Ordering::Relaxed),
+    )
 }
 
 fn transition_job_state(
@@ -636,6 +664,7 @@ mod tests {
             db_oid: 1,
             user_oid: 2,
             session_epoch: 3,
+            runtime_filter_exec_id: RuntimeFilterExecId::new(7, 11, 13, 3),
             scan_id: 4,
             producer_id: 1,
             producer_count: 2,
@@ -664,6 +693,10 @@ mod tests {
         assert_eq!(snapshot.descriptor.sql, "select 2");
         assert_eq!(snapshot.descriptor.fields[0].name, "id");
         assert_eq!(snapshot.descriptor.planner_fetch_hint, Some(128));
+        assert_eq!(
+            snapshot.runtime_filter_exec_id,
+            RuntimeFilterExecId::new(7, 11, 13, 3)
+        );
     }
 
     #[test]

--- a/pg/extension/src/shmem.rs
+++ b/pg/extension/src/shmem.rs
@@ -60,6 +60,8 @@ unsafe extern "C-unwind" fn pg_fusion_shmem_request_hook() {
     let runtime_filter_layout = RuntimeFilterPool::layout(config.runtime_filter_pool_config())
         .expect("runtime filter pool layout");
     let scan_worker_jobs_layout = ScanWorkerJobRegistry::layout();
+    #[cfg(feature = "pg_test")]
+    crate::test_gate::request_shmem_space();
 
     let total = control_layout
         .size
@@ -93,6 +95,8 @@ pub(crate) unsafe extern "C-unwind" fn init_shmem() {
     init_runtime_metrics(RUNTIME_METRICS_NAME, config.page_count);
     init_runtime_filters(RUNTIME_FILTER_POOL_NAME);
     init_scan_worker_jobs(SCAN_WORKER_JOBS_NAME);
+    #[cfg(feature = "pg_test")]
+    crate::test_gate::init_shmem();
 }
 
 pub(crate) fn attach_control_region() -> TransportRegion {

--- a/pg/extension/src/smoke_tests.rs
+++ b/pg/extension/src/smoke_tests.rs
@@ -46,11 +46,15 @@ fn wait_for_worker() {
 pub(crate) fn smoke_client() -> Client {
     wait_for_worker();
     let (port, dbname, user) = current_backend_connection();
+    connect_smoke_client(port, &dbname, &user)
+}
+
+fn connect_smoke_client(port: u16, dbname: &str, user: &str) -> Client {
     postgres::Config::new()
         .host("127.0.0.1")
         .port(port)
-        .user(&user)
-        .dbname(&dbname)
+        .user(user)
+        .dbname(dbname)
         .connect(postgres::NoTls)
         .expect("connect to pgrx test cluster")
 }
@@ -709,6 +713,68 @@ pub(crate) fn copy_select_smoke() {
         "COPY (SELECT ...) should return rows through pg_fusion custom scan"
     );
     assert_eq!(metrics_epoch, reset_epoch);
+}
+
+pub(crate) fn multi_page_result_transport_smoke() {
+    let mut client = smoke_client();
+    let mut tx = smoke_transaction(&mut client);
+    let table_name = "pg_temp.pgf_multi_page_result_transport_smoke";
+    const ROW_COUNT: usize = 4096;
+    const PAYLOAD_LEN: usize = 1024;
+
+    batch_execute_pg_fusion_disabled(
+        &mut tx,
+        &format!(
+            "\
+            CREATE TABLE {table_name} (id bigint NOT NULL, payload text NOT NULL);
+            INSERT INTO {table_name} (id, payload)
+            SELECT g::bigint, repeat('x', {PAYLOAD_LEN}) || g::text
+            FROM generate_series(1, {ROW_COUNT}) AS g
+            "
+        ),
+    );
+    simple_query_first_column_tx(&mut tx, "SELECT pg_fusion_metrics_reset()")
+        .expect("metrics reset before multi-page result smoke");
+
+    let rows = simple_query_first_column_rows_tx(
+        &mut tx,
+        &format!("SELECT payload FROM {table_name} ORDER BY id DESC"),
+    );
+    assert_eq!(rows.len(), ROW_COUNT);
+    assert!(
+        rows.first()
+            .is_some_and(|payload| payload.ends_with(&ROW_COUNT.to_string())),
+        "first sorted payload should come from highest id"
+    );
+    assert!(
+        rows.last().is_some_and(|payload| payload.ends_with('1')),
+        "last sorted payload should come from lowest id"
+    );
+
+    let summary = simple_query_first_column_tx(
+        &mut tx,
+        "\
+        SELECT concat(
+            coalesce(max(value) FILTER (WHERE metric = 'worker_result_pages_total'), 0), ',',
+            coalesce(max(value) FILTER (WHERE metric = 'result_pages_read_total'), 0)
+        )
+        FROM pg_fusion_metrics()
+        ",
+    )
+    .expect("multi-page result metric summary must return one row");
+    let parts = summary
+        .split(',')
+        .map(|part| part.parse::<i64>().expect("metric value must be integer"))
+        .collect::<Vec<_>>();
+    assert_eq!(parts.len(), 2);
+    assert!(
+        parts[0] > 1,
+        "worker_result_pages_total must prove multi-page result output: {summary}"
+    );
+    assert!(
+        parts[1] > 1,
+        "result_pages_read_total must prove backend consumed multiple result pages: {summary}"
+    );
 }
 
 pub(crate) fn copy_catalog_strict_smoke() {
@@ -1591,6 +1657,115 @@ pub(crate) fn heap_leader_only_scan_smoke() {
     client
         .batch_execute(&format!("DROP TABLE IF EXISTS {table_name}"))
         .expect("drop committed heap table for leader-only scan smoke");
+}
+
+pub(crate) fn worker_executes_second_backend_while_first_task_waits_smoke() {
+    let mut admin = smoke_client();
+    ensure_shared_preload(&mut admin);
+    let (port, dbname, user) = current_backend_connection();
+    let table_name = "public.pgf_worker_concurrent_tasks_smoke";
+    admin
+        .batch_execute(&format!(
+            "\
+            SELECT pg_advisory_lock({SMOKE_TEST_ADVISORY_LOCK});
+            SET pg_fusion.enable = off;
+            DROP TABLE IF EXISTS {table_name};
+            CREATE TABLE {table_name} AS
+            SELECT g::bigint AS id
+            FROM generate_series(1, 16) AS g;
+            ANALYZE {table_name};
+            SELECT tests.pg_fusion_test_execution_gate_reset();
+            "
+        ))
+        .expect("create committed worker concurrency fixture and enable test gate");
+
+    let first_table = table_name.to_owned();
+    let first_dbname = dbname.clone();
+    let first_user = user.clone();
+    let first_query = thread::spawn(move || -> Result<String, String> {
+        let mut client = connect_smoke_client(port, &first_dbname, &first_user);
+        ensure_shared_preload(&mut client);
+        client
+            .batch_execute(
+                "\
+                SET pg_fusion.enable = on;
+                SET max_parallel_workers_per_gather = 0;
+                SET statement_timeout = '10s';
+                ",
+            )
+            .map_err(|err| err.to_string())?;
+        simple_query_first_column_client(
+            &mut client,
+            &format!("SELECT sum(id)::bigint FROM {first_table}"),
+        )
+        .ok_or_else(|| "first backend query returned no rows".to_owned())
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let entered: i32 = simple_query_first_column_client(
+            &mut admin,
+            "SELECT tests.pg_fusion_test_execution_gate_entered()",
+        )
+        .expect("test gate entered counter must return one row")
+        .parse()
+        .expect("test gate entered counter must be an integer");
+        if entered >= 1 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "first backend did not enter the worker execution test gate"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let mut second = connect_smoke_client(port, &dbname, &user);
+    ensure_shared_preload(&mut second);
+    second
+        .batch_execute(
+            "\
+            SET pg_fusion.enable = on;
+            SET max_parallel_workers_per_gather = 0;
+            SET statement_timeout = '2s';
+            ",
+        )
+        .expect("configure second backend worker concurrency session");
+    let second_value: i64 = simple_query_first_column_client(
+        &mut second,
+        &format!("SELECT sum(id)::bigint FROM {table_name} WHERE id <= 2"),
+    )
+    .expect("second backend should finish while first backend waits in worker task")
+    .parse()
+    .expect("second backend result must be an integer");
+    assert_eq!(second_value, 3);
+
+    admin
+        .batch_execute(
+            "\
+            SET pg_fusion.enable = off;
+            SELECT tests.pg_fusion_test_execution_gate_release();
+            ",
+        )
+        .expect("release worker execution test gate");
+    let first_value: i64 = first_query
+        .join()
+        .expect("first backend query thread must not panic")
+        .expect("first backend query must finish after gate release")
+        .parse()
+        .expect("first backend result must be an integer");
+    assert_eq!(first_value, 136);
+
+    admin
+        .batch_execute(&format!(
+            "\
+            SET pg_fusion.enable = off;
+            SELECT tests.pg_fusion_test_execution_gate_disable();
+            DROP TABLE IF EXISTS {table_name};
+            SELECT pg_advisory_unlock({SMOKE_TEST_ADVISORY_LOCK});
+            "
+        ))
+        .expect("drop worker concurrency fixture and disable test gate");
 }
 
 pub(crate) fn statement_timeout_cleans_up_active_execution_smoke() {

--- a/pg/extension/src/test_gate.rs
+++ b/pg/extension/src/test_gate.rs
@@ -1,0 +1,128 @@
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant};
+
+use pgrx::pg_sys::AsPgCStr;
+
+const TEST_GATE_SHMEM_NAME: &str = "pg_fusion:test_execution_gate";
+const TEST_GATE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[repr(C)]
+struct TestExecutionGate {
+    enabled: AtomicU32,
+    claimed: AtomicU32,
+    entered: AtomicU32,
+    release: AtomicU32,
+}
+
+impl TestExecutionGate {
+    fn new() -> Self {
+        Self {
+            enabled: AtomicU32::new(0),
+            claimed: AtomicU32::new(0),
+            entered: AtomicU32::new(0),
+            release: AtomicU32::new(0),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct TestExecutionGateHandle {
+    ptr: NonNull<TestExecutionGate>,
+}
+
+unsafe impl Send for TestExecutionGateHandle {}
+unsafe impl Sync for TestExecutionGateHandle {}
+
+pub(crate) fn request_shmem_space() {
+    unsafe {
+        pgrx::pg_sys::RequestAddinShmemSpace(std::mem::size_of::<TestExecutionGate>());
+    }
+}
+
+pub(crate) unsafe fn init_shmem() {
+    let mut found = false;
+    let base = unsafe {
+        pgrx::pg_sys::ShmemInitStruct(
+            TEST_GATE_SHMEM_NAME.as_pg_cstr(),
+            std::mem::size_of::<TestExecutionGate>(),
+            &mut found,
+        ) as *mut TestExecutionGate
+    };
+    let base = NonNull::new(base).expect("test execution gate shmem");
+    if !found {
+        unsafe {
+            base.as_ptr().write(TestExecutionGate::new());
+        }
+    }
+}
+
+pub(crate) fn attach() -> TestExecutionGateHandle {
+    let mut found = false;
+    let base = unsafe {
+        pgrx::pg_sys::ShmemInitStruct(
+            TEST_GATE_SHMEM_NAME.as_pg_cstr(),
+            std::mem::size_of::<TestExecutionGate>(),
+            &mut found,
+        ) as *mut TestExecutionGate
+    };
+    assert!(
+        found,
+        "test execution gate shmem must already be initialized"
+    );
+    TestExecutionGateHandle {
+        ptr: NonNull::new(base).expect("test execution gate shmem base"),
+    }
+}
+
+impl TestExecutionGateHandle {
+    fn gate(self) -> &'static TestExecutionGate {
+        unsafe { self.ptr.as_ref() }
+    }
+
+    pub(crate) fn reset(self) {
+        let gate = self.gate();
+        gate.release.store(0, Ordering::Release);
+        gate.entered.store(0, Ordering::Release);
+        gate.claimed.store(0, Ordering::Release);
+        gate.enabled.store(1, Ordering::Release);
+    }
+
+    pub(crate) fn release(self) {
+        let gate = self.gate();
+        gate.release.store(1, Ordering::Release);
+        gate.enabled.store(0, Ordering::Release);
+    }
+
+    pub(crate) fn disable(self) {
+        let gate = self.gate();
+        gate.release.store(1, Ordering::Release);
+        gate.enabled.store(0, Ordering::Release);
+        gate.claimed.store(0, Ordering::Release);
+        gate.entered.store(0, Ordering::Release);
+    }
+
+    pub(crate) fn entered(self) -> i32 {
+        self.gate().entered.load(Ordering::Acquire) as i32
+    }
+
+    pub(crate) async fn wait_at_execution_start(self) {
+        let gate = self.gate();
+        if gate.enabled.load(Ordering::Acquire) == 0 {
+            return;
+        }
+        if gate
+            .claimed
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        gate.entered.fetch_add(1, Ordering::AcqRel);
+        let deadline = Instant::now() + TEST_GATE_TIMEOUT;
+        while gate.release.load(Ordering::Acquire) == 0 && Instant::now() < deadline {
+            tokio::task::yield_now().await;
+        }
+    }
+}

--- a/pg/extension/src/worker.rs
+++ b/pg/extension/src/worker.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::CStr;
 use std::io::{self, Read, Write};
 use std::os::fd::{AsRawFd, RawFd};
@@ -45,11 +45,79 @@ type WorkerTaskSender = mpsc::Sender<WorkerTaskEvent>;
 type WorkerTaskReceiver = mpsc::Receiver<WorkerTaskEvent>;
 type WorkerTaskAck = oneshot::Sender<Result<(), WorkerRuntimeError>>;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PendingTerminalControl {
+    Complete {
+        session_epoch: u64,
+    },
+    Fail {
+        session_epoch: u64,
+        code: ExecutionFailureCode,
+        detail: Option<String>,
+    },
+}
+
+impl PendingTerminalControl {
+    fn session_epoch(&self) -> u64 {
+        match self {
+            Self::Complete { session_epoch } | Self::Fail { session_epoch, .. } => *session_epoch,
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Complete { .. } => "CompleteExecution",
+            Self::Fail { .. } => "FailExecution",
+        }
+    }
+
+    fn to_message(&self) -> WorkerExecutionToBackend {
+        match self {
+            Self::Complete { session_epoch } => WorkerExecutionToBackend::CompleteExecution {
+                session_epoch: *session_epoch,
+            },
+            Self::Fail {
+                session_epoch,
+                code,
+                detail,
+            } => WorkerExecutionToBackend::FailExecution {
+                session_epoch: *session_epoch,
+                code: *code,
+                detail: detail.clone(),
+            },
+        }
+    }
+}
+
+enum PeerPollOutcome {
+    Steps(VecDeque<WorkerRuntimeStep>),
+    DetachedIdle,
+    ReservationCancelled,
+    ActiveReservationCancelViolation(WorkerRuntimeError),
+}
+
+#[derive(Debug)]
+enum AdmissionPollOutcome {
+    Idle,
+    Requested,
+    Cancelled,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PeerSchedulerState {
+    Active,
+    Reserved,
+    Retained,
+    Queued,
+    Unknown,
+}
+
 struct ActiveWorkerExecution {
     runtime: WorkerRuntimeCore,
     plan_rx: Option<IssuedRx>,
     task: Option<JoinHandle<()>>,
     worker_start_ns: Option<u64>,
+    pending_terminal: Option<PendingTerminalControl>,
 }
 
 impl ActiveWorkerExecution {
@@ -59,6 +127,7 @@ impl ActiveWorkerExecution {
             plan_rx: None,
             task: None,
             worker_start_ns: None,
+            pending_terminal: None,
         }
     }
 
@@ -66,6 +135,195 @@ impl ActiveWorkerExecution {
         if let Some(task) = self.task.take() {
             task.abort();
         }
+    }
+}
+
+struct ExecutionRegistry {
+    entries: HashMap<BackendLeaseSlot, ActiveWorkerExecution>,
+    active_peers: HashSet<BackendLeaseSlot>,
+    reserved_peers: HashSet<BackendLeaseSlot>,
+    queued_reservations: VecDeque<BackendLeaseSlot>,
+    queued_peers: HashSet<BackendLeaseSlot>,
+    retained_by_slot: HashMap<u32, BackendLeaseSlot>,
+}
+
+impl ExecutionRegistry {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::with_capacity(capacity),
+            active_peers: HashSet::with_capacity(capacity),
+            reserved_peers: HashSet::with_capacity(capacity),
+            queued_reservations: VecDeque::with_capacity(capacity),
+            queued_peers: HashSet::with_capacity(capacity),
+            retained_by_slot: HashMap::with_capacity(capacity),
+        }
+    }
+
+    #[cfg(test)]
+    fn active_len(&self) -> usize {
+        self.active_peers.len()
+    }
+
+    fn admitted_len(&self) -> usize {
+        self.active_peers.len() + self.reserved_peers.len()
+    }
+
+    fn has_admission_capacity(&self, max_fusion_tasks: usize) -> bool {
+        self.admitted_len() < max_fusion_tasks
+    }
+
+    fn active_peers(&self) -> Vec<BackendLeaseSlot> {
+        self.active_peers.iter().copied().collect()
+    }
+
+    fn reserved_peers(&self) -> Vec<BackendLeaseSlot> {
+        self.reserved_peers.iter().copied().collect()
+    }
+
+    fn pending_terminal_peers(&self) -> Vec<BackendLeaseSlot> {
+        self.entries
+            .iter()
+            .filter_map(|(peer, execution)| execution.pending_terminal.as_ref().map(|_| *peer))
+            .collect()
+    }
+
+    fn contains_active(&self, peer: BackendLeaseSlot) -> bool {
+        self.active_peers.contains(&peer)
+    }
+
+    fn contains_reserved(&self, peer: BackendLeaseSlot) -> bool {
+        self.reserved_peers.contains(&peer)
+    }
+
+    fn contains_queued(&self, peer: BackendLeaseSlot) -> bool {
+        self.queued_peers.contains(&peer)
+    }
+
+    fn peer_scheduler_state(&self, peer: BackendLeaseSlot) -> PeerSchedulerState {
+        if self.active_peers.contains(&peer) {
+            PeerSchedulerState::Active
+        } else if self.reserved_peers.contains(&peer) {
+            PeerSchedulerState::Reserved
+        } else if self.retained_by_slot.get(&peer.slot_id()) == Some(&peer)
+            && self.entries.contains_key(&peer)
+        {
+            PeerSchedulerState::Retained
+        } else if self.queued_peers.contains(&peer) {
+            PeerSchedulerState::Queued
+        } else {
+            PeerSchedulerState::Unknown
+        }
+    }
+
+    fn has_queued_reservations(&self) -> bool {
+        !self.queued_peers.is_empty()
+    }
+
+    fn reserve(&mut self, peer: BackendLeaseSlot) {
+        self.remove_queued(peer);
+        self.evict_retained_for_slot(peer.slot_id(), None);
+        self.reserved_peers.insert(peer);
+    }
+
+    fn queue_reservation(&mut self, peer: BackendLeaseSlot) {
+        if self.reserved_peers.contains(&peer) || !self.queued_peers.insert(peer) {
+            return;
+        }
+        self.queued_reservations.push_back(peer);
+    }
+
+    fn cancel_reservation(&mut self, peer: BackendLeaseSlot) {
+        self.reserved_peers.remove(&peer);
+        self.remove_queued(peer);
+    }
+
+    fn remove_queued(&mut self, peer: BackendLeaseSlot) {
+        if !self.queued_peers.remove(&peer) {
+            return;
+        }
+        self.queued_reservations
+            .retain(|queued_peer| *queued_peer != peer);
+    }
+
+    fn pop_next_queued_reservation(&mut self) -> Option<BackendLeaseSlot> {
+        while let Some(peer) = self.queued_reservations.pop_front() {
+            if self.queued_peers.remove(&peer) {
+                return Some(peer);
+            }
+        }
+        None
+    }
+
+    fn remove(&mut self, peer: BackendLeaseSlot) -> Option<ActiveWorkerExecution> {
+        let execution = self.entries.remove(&peer);
+        if execution.is_some() {
+            self.active_peers.remove(&peer);
+            if self.retained_by_slot.get(&peer.slot_id()) == Some(&peer) {
+                self.retained_by_slot.remove(&peer.slot_id());
+            }
+        }
+        execution
+    }
+
+    fn retain_after_poll(&mut self, peer: BackendLeaseSlot, mut execution: ActiveWorkerExecution) {
+        if execution.runtime.active_peer() == Some(peer) {
+            self.reserved_peers.remove(&peer);
+            self.evict_retained_for_slot(peer.slot_id(), Some(peer));
+            self.active_peers.insert(peer);
+            self.entries.insert(peer, execution);
+        } else if execution.runtime.retained_peer() == Some(peer) {
+            self.reserved_peers.remove(&peer);
+            self.evict_retained_for_slot(peer.slot_id(), Some(peer));
+            execution.abort_task();
+            execution.plan_rx.take();
+            self.active_peers.remove(&peer);
+            self.retained_by_slot.insert(peer.slot_id(), peer);
+            self.entries.insert(peer, execution);
+        } else {
+            execution.abort_task();
+        }
+    }
+
+    fn evict_retained_for_slot(&mut self, slot_id: u32, keep: Option<BackendLeaseSlot>) {
+        let Some(retained_peer) = self.retained_by_slot.get(&slot_id).copied() else {
+            return;
+        };
+        if Some(retained_peer) == keep {
+            return;
+        }
+        self.retained_by_slot.remove(&slot_id);
+        if let Some(mut execution) = self.entries.remove(&retained_peer) {
+            self.active_peers.remove(&retained_peer);
+            execution.abort_task();
+        }
+    }
+
+    fn active_session_matches(&self, peer: BackendLeaseSlot, session_epoch: u64) -> bool {
+        self.entries
+            .get(&peer)
+            .and_then(|execution| execution.runtime.session_epoch())
+            == Some(session_epoch)
+    }
+
+    fn remove_active_session(
+        &mut self,
+        peer: BackendLeaseSlot,
+        session_epoch: u64,
+    ) -> Option<ActiveWorkerExecution> {
+        if self.active_session_matches(peer, session_epoch) {
+            self.remove(peer)
+        } else {
+            None
+        }
+    }
+
+    fn abort_all(&mut self) {
+        for execution in self.entries.values_mut() {
+            execution.abort_task();
+        }
+        self.reserved_peers.clear();
+        self.queued_reservations.clear();
+        self.queued_peers.clear();
     }
 }
 
@@ -393,7 +651,8 @@ fn run_worker_main() -> Result<(), WorkerRuntimeError> {
             let (task_event_tx, mut task_rx) =
                 mpsc::channel(config.max_fusion_tasks.saturating_mul(4).max(1));
             let task_tx = WorkerTaskNotifier::new(task_event_tx, scheduler_wake.sender());
-            let mut executions: HashMap<BackendLeaseSlot, ActiveWorkerExecution> = HashMap::new();
+            let mut executions =
+                ExecutionRegistry::with_capacity(config.control_slot_count as usize);
             #[cfg(feature = "pg_test")]
             let test_execution_gate = crate::test_gate::attach();
             let df_runtime_plan = resolve_datafusion_runtime_plan(config.worker_threads);
@@ -423,7 +682,9 @@ fn run_worker_main() -> Result<(), WorkerRuntimeError> {
                     test_execution_gate,
                 )?;
 
-                let active_peers = executions.keys().copied().collect::<Vec<_>>();
+                retry_pending_terminal_controls(&mut executions, &mut transport)?;
+
+                let active_peers = executions.active_peers();
                 for peer in active_peers {
                     trace!(
                         component = "worker",
@@ -448,26 +709,97 @@ fn run_worker_main() -> Result<(), WorkerRuntimeError> {
                     )?;
                 }
 
+                let reserved_peers = executions.reserved_peers();
+                for peer in reserved_peers {
+                    trace!(
+                        component = "worker",
+                        peer = ?peer,
+                        "worker probing reserved backend peer"
+                    );
+                    poll_execution_peer(
+                        &mut executions,
+                        &mut transport,
+                        &df_runtime,
+                        &mut spill_runtime,
+                        &config,
+                        &worker_config,
+                        &scan_source,
+                        &task_tx,
+                        #[cfg(feature = "pg_test")]
+                        test_execution_gate,
+                        peer,
+                        page_pool,
+                        issuance_pool,
+                        metrics,
+                    )?;
+                }
+
                 let mut ready_cursor = 0;
                 while let Some(peer) = transport.next_ready_backend_lease(&mut ready_cursor) {
-                    if executions.contains_key(&peer) {
-                        continue;
+                    match executions.peer_scheduler_state(peer) {
+                        PeerSchedulerState::Active => continue,
+                        PeerSchedulerState::Reserved | PeerSchedulerState::Retained => {
+                            if tracing::enabled!(Level::TRACE) {
+                                trace!(
+                                    component = "worker",
+                                    peer = ?peer,
+                                    state = ?executions.peer_scheduler_state(peer),
+                                    "worker polling known backend peer"
+                                );
+                            }
+                            poll_execution_peer(
+                                &mut executions,
+                                &mut transport,
+                                &df_runtime,
+                                &mut spill_runtime,
+                                &config,
+                                &worker_config,
+                                &scan_source,
+                                &task_tx,
+                                #[cfg(feature = "pg_test")]
+                                test_execution_gate,
+                                peer,
+                                page_pool,
+                                issuance_pool,
+                                metrics,
+                            )?;
+                        }
+                        PeerSchedulerState::Queued | PeerSchedulerState::Unknown => {
+                            let admission = recv_backend_admission_request(&mut transport, peer)?;
+                            match admission {
+                                AdmissionPollOutcome::Idle => {}
+                                AdmissionPollOutcome::Cancelled => {
+                                    executions.cancel_reservation(peer);
+                                }
+                                AdmissionPollOutcome::Requested => {
+                                    handle_requested_execution_reservation(
+                                        &mut executions,
+                                        &mut transport,
+                                        peer,
+                                        config.max_fusion_tasks,
+                                    )?;
+                                }
+                            }
+                        }
                     }
-                    if executions.len() >= config.max_fusion_tasks {
-                        trace!(
-                            component = "worker",
-                            peer = ?peer,
-                            active_executions = executions.len(),
-                            max_fusion_tasks = config.max_fusion_tasks,
-                            "worker deferring new backend peer because fusion task limit is reached"
-                        );
+                }
+
+                grant_queued_execution_reservations(
+                    &mut executions,
+                    &mut transport,
+                    config.max_fusion_tasks,
+                )?;
+
+                let mut ready_cursor = 0;
+                while let Some(peer) = transport.next_ready_backend_lease(&mut ready_cursor) {
+                    if executions.contains_active(peer) || !executions.contains_reserved(peer) {
                         continue;
                     }
                     if tracing::enabled!(Level::TRACE) {
                         trace!(
                             component = "worker",
                             peer = ?peer,
-                            "worker polling ready backend peer"
+                            "worker polling admitted backend peer after queued grants"
                         );
                     }
                     poll_execution_peer(
@@ -502,11 +834,17 @@ fn run_worker_main() -> Result<(), WorkerRuntimeError> {
                     #[cfg(feature = "pg_test")]
                     test_execution_gate,
                 )?;
+
+                retry_pending_terminal_controls(&mut executions, &mut transport)?;
+
+                grant_queued_execution_reservations(
+                    &mut executions,
+                    &mut transport,
+                    config.max_fusion_tasks,
+                )?;
             }
 
-            for execution in executions.values_mut() {
-                execution.abort_task();
-            }
+            executions.abort_all();
             Ok(())
         })();
 
@@ -554,9 +892,151 @@ fn wait_worker_scheduler(wake: &mut WorkerSchedulerWake, timeout: Duration) -> b
     !BackgroundWorker::sigterm_received() && !postmaster_died
 }
 
+fn recv_backend_admission_request(
+    transport: &mut TransportWorkerRuntime,
+    peer: BackendLeaseSlot,
+) -> Result<AdmissionPollOutcome, WorkerRuntimeError> {
+    let mut requested = false;
+    let mut cancelled = false;
+    let recv_result = transport.recv_peer_frames(peer, |bytes| {
+        match WorkerRuntimeCore::decode_inbound(bytes)? {
+            DecodedInbound::Control(
+                protocol::BackendExecutionToWorkerRef::ReserveExecutionSlot,
+            ) => {
+                requested = true;
+            }
+            DecodedInbound::Control(
+                protocol::BackendExecutionToWorkerRef::CancelExecutionReservation,
+            ) => {
+                cancelled = true;
+            }
+            DecodedInbound::Control(message) => {
+                return Err(WorkerRuntimeError::ProtocolViolation(format!(
+                    "backend sent {message:?} before execution reservation was granted"
+                )));
+            }
+            DecodedInbound::IssuedFrame(_) => {
+                return Err(WorkerRuntimeError::ProtocolViolation(
+                    "backend sent plan frame before execution reservation was granted".into(),
+                ));
+            }
+        }
+        Ok(())
+    });
+
+    match recv_result {
+        Ok(()) if cancelled => Ok(AdmissionPollOutcome::Cancelled),
+        Ok(()) if requested => Ok(AdmissionPollOutcome::Requested),
+        Ok(()) => Ok(AdmissionPollOutcome::Idle),
+        Err(err) if is_detached_backend_peer_error(&err) => {
+            warn!(
+                component = "worker",
+                peer = ?peer,
+                error = %err,
+                "worker could not read admission request because backend peer detached"
+            );
+            Ok(AdmissionPollOutcome::Cancelled)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn grant_execution_reservation(
+    executions: &mut ExecutionRegistry,
+    transport: &mut TransportWorkerRuntime,
+    peer: BackendLeaseSlot,
+) -> Result<bool, WorkerRuntimeError> {
+    executions.reserve(peer);
+    match transport.send_peer_message(peer, WorkerExecutionToBackend::ExecutionSlotReserved) {
+        Ok(_) => Ok(true),
+        Err(err) if is_detached_backend_peer_error(&err) => {
+            executions.cancel_reservation(peer);
+            warn!(
+                component = "worker",
+                peer = ?peer,
+                error = %err,
+                "worker could not grant execution reservation because backend peer detached"
+            );
+            Ok(false)
+        }
+        Err(err) => {
+            executions.cancel_reservation(peer);
+            Err(err)
+        }
+    }
+}
+
+fn handle_requested_execution_reservation(
+    executions: &mut ExecutionRegistry,
+    transport: &mut TransportWorkerRuntime,
+    peer: BackendLeaseSlot,
+    max_fusion_tasks: usize,
+) -> Result<(), WorkerRuntimeError> {
+    if executions.contains_queued(peer) {
+        trace!(
+            component = "worker",
+            peer = ?peer,
+            "worker observed duplicate queued backend execution reservation"
+        );
+    } else if executions.has_queued_reservations() {
+        executions.queue_reservation(peer);
+        trace!(
+            component = "worker",
+            peer = ?peer,
+            admitted_executions = executions.admitted_len(),
+            max_fusion_tasks,
+            "worker queued backend execution reservation behind older reservations"
+        );
+    } else if executions.has_admission_capacity(max_fusion_tasks) {
+        let granted = grant_execution_reservation(executions, transport, peer)?;
+        if granted {
+            trace!(
+                component = "worker",
+                peer = ?peer,
+                admitted_executions = executions.admitted_len(),
+                max_fusion_tasks,
+                "worker granted backend execution reservation"
+            );
+        }
+    } else {
+        executions.queue_reservation(peer);
+        trace!(
+            component = "worker",
+            peer = ?peer,
+            admitted_executions = executions.admitted_len(),
+            max_fusion_tasks,
+            "worker queued backend execution reservation because fusion task limit is reached"
+        );
+    }
+    Ok(())
+}
+
+fn grant_queued_execution_reservations(
+    executions: &mut ExecutionRegistry,
+    transport: &mut TransportWorkerRuntime,
+    max_fusion_tasks: usize,
+) -> Result<(), WorkerRuntimeError> {
+    while executions.has_admission_capacity(max_fusion_tasks) {
+        let Some(peer) = executions.pop_next_queued_reservation() else {
+            break;
+        };
+        let granted = grant_execution_reservation(executions, transport, peer)?;
+        if granted {
+            trace!(
+                component = "worker",
+                peer = ?peer,
+                admitted_executions = executions.admitted_len(),
+                max_fusion_tasks,
+                "worker granted queued backend execution reservation"
+            );
+        }
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn poll_execution_peer(
-    executions: &mut HashMap<BackendLeaseSlot, ActiveWorkerExecution>,
+    executions: &mut ExecutionRegistry,
     transport: &mut TransportWorkerRuntime,
     df_runtime: &tokio::runtime::Runtime,
     spill_runtime: &mut WorkerSpillRuntime,
@@ -570,10 +1050,16 @@ fn poll_execution_peer(
     issuance_pool: IssuancePool,
     metrics: RuntimeMetrics,
 ) -> Result<(), WorkerRuntimeError> {
-    let mut execution = executions.remove(&peer).unwrap_or_else(|| {
+    let execution = executions.remove(peer);
+    if execution.is_none() && !executions.contains_reserved(peer) {
+        return Err(WorkerRuntimeError::ProtocolViolation(format!(
+            "backend peer {peer:?} sent execution frames without a granted reservation"
+        )));
+    }
+    let mut execution = execution.unwrap_or_else(|| {
         ActiveWorkerExecution::new(worker_config.clone(), Arc::clone(scan_source))
     });
-    let steps = recv_backend_peer_steps(
+    let poll = recv_backend_peer_steps(
         transport,
         &mut execution.runtime,
         peer,
@@ -581,31 +1067,56 @@ fn poll_execution_peer(
         issuance_pool,
         &mut execution.plan_rx,
     )?;
-    handle_steps(
-        transport,
-        &mut execution,
-        df_runtime,
-        spill_runtime,
-        config,
-        page_pool,
-        issuance_pool,
-        metrics,
-        task_tx,
-        #[cfg(feature = "pg_test")]
-        test_execution_gate,
-        steps,
-    )?;
-    if execution.runtime.active_peer().is_some() {
-        executions.insert(peer, execution);
-    } else {
-        execution.abort_task();
+    match poll {
+        PeerPollOutcome::Steps(steps) => {
+            handle_steps(
+                transport,
+                &mut execution,
+                df_runtime,
+                spill_runtime,
+                config,
+                page_pool,
+                issuance_pool,
+                metrics,
+                task_tx,
+                #[cfg(feature = "pg_test")]
+                test_execution_gate,
+                steps,
+            )?;
+            executions.retain_after_poll(peer, execution);
+        }
+        PeerPollOutcome::DetachedIdle => {
+            execution.abort_task();
+            executions.cancel_reservation(peer);
+        }
+        PeerPollOutcome::ReservationCancelled => {
+            execution.abort_task();
+            executions.cancel_reservation(peer);
+        }
+        PeerPollOutcome::ActiveReservationCancelViolation(err) => {
+            let session_epoch = execution
+                .runtime
+                .session_epoch()
+                .ok_or(WorkerRuntimeError::NoActiveExecution)?;
+            execution.abort_task();
+            finish_execution_task(
+                transport,
+                &mut execution,
+                config,
+                metrics,
+                peer,
+                session_epoch,
+                Err(err),
+            )?;
+            executions.retain_after_poll(peer, execution);
+        }
     }
     Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
 fn drain_task_events(
-    executions: &mut HashMap<BackendLeaseSlot, ActiveWorkerExecution>,
+    executions: &mut ExecutionRegistry,
     transport: &mut TransportWorkerRuntime,
     df_runtime: &tokio::runtime::Runtime,
     spill_runtime: &mut WorkerSpillRuntime,
@@ -638,7 +1149,7 @@ fn drain_task_events(
 
 #[allow(clippy::too_many_arguments)]
 fn handle_task_event(
-    executions: &mut HashMap<BackendLeaseSlot, ActiveWorkerExecution>,
+    executions: &mut ExecutionRegistry,
     transport: &mut TransportWorkerRuntime,
     df_runtime: &tokio::runtime::Runtime,
     spill_runtime: &mut WorkerSpillRuntime,
@@ -652,32 +1163,36 @@ fn handle_task_event(
 ) -> Result<(), WorkerRuntimeError> {
     match event {
         WorkerTaskEvent::PhysicalPlanningFinished { peer, flow, result } => {
-            let Some(mut execution) = executions.remove(&peer) else {
+            let Some(mut execution) = executions.remove(peer) else {
                 return Ok(());
             };
-            execution.task = None;
-            let step = execution
+            let (step, planning_err) = execution
                 .runtime
-                .finish_physical_planning(peer, flow, result)?;
-            handle_steps(
-                transport,
-                &mut execution,
-                df_runtime,
-                spill_runtime,
-                config,
-                page_pool,
-                issuance_pool,
-                metrics,
-                task_tx,
-                #[cfg(feature = "pg_test")]
-                test_execution_gate,
-                VecDeque::from([step]),
-            )?;
-            if execution.runtime.active_peer().is_some() {
-                executions.insert(peer, execution);
-            } else {
-                execution.abort_task();
+                .finish_physical_planning_step(peer, flow, result)?;
+            if planning_err.is_some()
+                || !matches!(step, WorkerRuntimeStep::PlanningResultIgnored { .. })
+            {
+                execution.task = None;
             }
+            if let Some(err) = planning_err {
+                finish_failed_terminal_step(transport, &mut execution, config, peer, err, step)?;
+            } else {
+                handle_steps(
+                    transport,
+                    &mut execution,
+                    df_runtime,
+                    spill_runtime,
+                    config,
+                    page_pool,
+                    issuance_pool,
+                    metrics,
+                    task_tx,
+                    #[cfg(feature = "pg_test")]
+                    test_execution_gate,
+                    VecDeque::from([step]),
+                )?;
+            }
+            executions.retain_after_poll(peer, execution);
         }
         WorkerTaskEvent::ResultPage {
             peer,
@@ -685,7 +1200,7 @@ fn handle_task_event(
             outbound,
             ack,
         } => {
-            let result = if active_execution_session_matches(executions, peer, session_epoch) {
+            let result = if executions.active_session_matches(peer, session_epoch) {
                 send_result_page_from_task(transport, metrics, peer, session_epoch, outbound)
             } else {
                 Err(stale_execution_task_error(peer, session_epoch))
@@ -698,7 +1213,7 @@ fn handle_task_event(
             frame,
             ack,
         } => {
-            let result = if active_execution_session_matches(executions, peer, session_epoch) {
+            let result = if executions.active_session_matches(peer, session_epoch) {
                 send_result_close_from_task(transport, peer, session_epoch, frame)
             } else {
                 Err(stale_execution_task_error(peer, session_epoch))
@@ -710,7 +1225,7 @@ fn handle_task_event(
             session_epoch,
             result,
         } => {
-            let Some(mut execution) = executions.remove(&peer) else {
+            let Some(mut execution) = executions.remove_active_session(peer, session_epoch) else {
                 return Ok(());
             };
             execution.task = None;
@@ -723,25 +1238,10 @@ fn handle_task_event(
                 session_epoch,
                 result,
             )?;
-            if execution.runtime.active_peer().is_some() {
-                executions.insert(peer, execution);
-            } else {
-                execution.abort_task();
-            }
+            executions.retain_after_poll(peer, execution);
         }
     }
     Ok(())
-}
-
-fn active_execution_session_matches(
-    executions: &HashMap<BackendLeaseSlot, ActiveWorkerExecution>,
-    peer: BackendLeaseSlot,
-    session_epoch: u64,
-) -> bool {
-    executions
-        .get(&peer)
-        .and_then(|execution| execution.runtime.session_epoch())
-        == Some(session_epoch)
 }
 
 fn recv_backend_peer_steps(
@@ -751,11 +1251,39 @@ fn recv_backend_peer_steps(
     page_pool: PagePool,
     issuance_pool: IssuancePool,
     plan_rx: &mut Option<IssuedRx>,
-) -> Result<VecDeque<WorkerRuntimeStep>, WorkerRuntimeError> {
+) -> Result<PeerPollOutcome, WorkerRuntimeError> {
     let mut steps = VecDeque::new();
+    let mut reservation_cancelled = false;
+    let mut active_reservation_cancel_violation = None;
     let recv_result = transport.recv_peer_frames(peer, |bytes| {
+        if active_reservation_cancel_violation.is_some() {
+            return Ok(());
+        }
         let decoded = WorkerRuntimeCore::decode_inbound(bytes)?;
         let step = match decoded {
+            DecodedInbound::Control(
+                protocol::BackendExecutionToWorkerRef::ReserveExecutionSlot,
+            ) => {
+                return Ok(());
+            }
+            DecodedInbound::Control(
+                protocol::BackendExecutionToWorkerRef::CancelExecutionReservation,
+            ) => {
+                if runtime.active_peer() == Some(peer) {
+                    active_reservation_cancel_violation =
+                        Some(WorkerRuntimeError::ProtocolViolation(format!(
+                            "backend peer {peer:?} sent CancelExecutionReservation after execution started"
+                        )));
+                } else if runtime.retained_peer() == Some(peer) {
+                    // Reservation cancellation is only meaningful before
+                    // StartExecution. Once the runtime is retained, treat it
+                    // like stale pre-session traffic so pending terminal
+                    // delivery is not discarded.
+                } else {
+                    reservation_cancelled = true;
+                }
+                return Ok(());
+            }
             DecodedInbound::Control(message) => runtime.accept_backend_control(peer, message)?,
             DecodedInbound::IssuedFrame(frame) => {
                 let rx = plan_rx.as_ref().ok_or_else(|| {
@@ -777,7 +1305,15 @@ fn recv_backend_peer_steps(
     });
 
     match recv_result {
-        Ok(()) => Ok(steps),
+        Ok(()) if active_reservation_cancel_violation.is_some() => {
+            Ok(PeerPollOutcome::ActiveReservationCancelViolation(
+                active_reservation_cancel_violation.expect("violation error"),
+            ))
+        }
+        Ok(()) if reservation_cancelled && steps.is_empty() => {
+            Ok(PeerPollOutcome::ReservationCancelled)
+        }
+        Ok(()) => Ok(PeerPollOutcome::Steps(steps)),
         Err(err) if is_detached_backend_peer_error(&err) => {
             warn!(
                 component = "worker",
@@ -788,8 +1324,9 @@ fn recv_backend_peer_steps(
             steps.clear();
             if let Some(step) = runtime.cancel_detached_backend_peer(peer)? {
                 steps.push_back(step);
+                return Ok(PeerPollOutcome::Steps(steps));
             }
-            Ok(steps)
+            Ok(PeerPollOutcome::DetachedIdle)
         }
         Err(err) => Err(err),
     }
@@ -858,31 +1395,21 @@ fn finish_execution_task(
                 peer = ?peer,
                 "worker finished execution successfully and is sending CompleteExecution"
             );
-            if let Err(err) = transport.send_peer_message(
-                peer,
-                WorkerExecutionToBackend::CompleteExecution { session_epoch },
-            ) {
-                if is_detached_backend_peer_error(&err) {
-                    warn!(
-                        component = "worker",
-                        session_epoch,
-                        peer = ?peer,
-                        error = %err,
-                        "worker could not send CompleteExecution because backend peer detached"
-                    );
-                } else {
-                    return Err(err);
-                }
-            }
             if let Some(worker_start) = worker_start {
                 metrics.add_elapsed(MetricId::WorkerTotalNs, worker_start);
             }
             let step = execution.runtime.mark_execution_complete()?;
             handle_terminal_step(execution, step)?;
+            queue_and_try_send_terminal_control(
+                transport,
+                execution,
+                peer,
+                PendingTerminalControl::Complete { session_epoch },
+            )?;
         }
         Err(err) => {
             let detail =
-                worker_execution_failure_detail(&err, config.control_backend_to_worker_capacity);
+                worker_execution_failure_detail(&err, config.control_worker_to_backend_capacity);
             warn!(
                 component = "worker",
                 session_epoch,
@@ -890,26 +1417,6 @@ fn finish_execution_task(
                 error = %err,
                 "worker execution failed locally; sending FailExecution"
             );
-            if let Err(send_err) = transport.send_peer_message(
-                peer,
-                WorkerExecutionToBackend::FailExecution {
-                    session_epoch,
-                    code: ExecutionFailureCode::Internal,
-                    detail,
-                },
-            ) {
-                if is_detached_backend_peer_error(&send_err) {
-                    warn!(
-                        component = "worker",
-                        session_epoch,
-                        peer = ?peer,
-                        error = %send_err,
-                        "worker could not send FailExecution because backend peer detached"
-                    );
-                } else {
-                    return Err(send_err);
-                }
-            }
             if let Some(worker_start) = worker_start {
                 metrics.add_elapsed(MetricId::WorkerTotalNs, worker_start);
             }
@@ -917,9 +1424,132 @@ fn finish_execution_task(
                 .runtime
                 .fail_execution_locally(ExecutionFailureCode::Internal, None)?;
             handle_terminal_step(execution, step)?;
+            queue_and_try_send_terminal_control(
+                transport,
+                execution,
+                peer,
+                PendingTerminalControl::Fail {
+                    session_epoch,
+                    code: ExecutionFailureCode::Internal,
+                    detail,
+                },
+            )?;
         }
     }
     Ok(())
+}
+
+fn finish_failed_terminal_step(
+    transport: &mut TransportWorkerRuntime,
+    execution: &mut ActiveWorkerExecution,
+    config: &crate::HostConfig,
+    peer: BackendLeaseSlot,
+    err: WorkerRuntimeError,
+    step: WorkerRuntimeStep,
+) -> Result<(), WorkerRuntimeError> {
+    let WorkerRuntimeStep::ExecutionFailed {
+        session_epoch,
+        code,
+        ..
+    } = step
+    else {
+        return Err(WorkerRuntimeError::ProtocolViolation(format!(
+            "planning failure produced non-failure runtime step: {step:?}"
+        )));
+    };
+    let detail = worker_execution_failure_detail(&err, config.control_worker_to_backend_capacity);
+    warn!(
+        component = "worker",
+        session_epoch,
+        peer = ?peer,
+        error = %err,
+        "worker physical planning failed locally; sending FailExecution"
+    );
+    handle_terminal_step(
+        execution,
+        WorkerRuntimeStep::ExecutionFailed {
+            session_epoch,
+            code,
+            detail: None,
+        },
+    )?;
+    queue_and_try_send_terminal_control(
+        transport,
+        execution,
+        peer,
+        PendingTerminalControl::Fail {
+            session_epoch,
+            code,
+            detail,
+        },
+    )
+}
+
+fn queue_and_try_send_terminal_control(
+    transport: &mut TransportWorkerRuntime,
+    execution: &mut ActiveWorkerExecution,
+    peer: BackendLeaseSlot,
+    terminal: PendingTerminalControl,
+) -> Result<(), WorkerRuntimeError> {
+    execution.pending_terminal = Some(terminal);
+    retry_pending_terminal_control(transport, execution, peer)
+}
+
+fn retry_pending_terminal_controls(
+    executions: &mut ExecutionRegistry,
+    transport: &mut TransportWorkerRuntime,
+) -> Result<(), WorkerRuntimeError> {
+    for peer in executions.pending_terminal_peers() {
+        let Some(mut execution) = executions.remove(peer) else {
+            continue;
+        };
+        let retry = retry_pending_terminal_control(transport, &mut execution, peer);
+        executions.retain_after_poll(peer, execution);
+        retry?;
+    }
+    Ok(())
+}
+
+fn retry_pending_terminal_control(
+    transport: &mut TransportWorkerRuntime,
+    execution: &mut ActiveWorkerExecution,
+    peer: BackendLeaseSlot,
+) -> Result<(), WorkerRuntimeError> {
+    let Some(terminal) = execution.pending_terminal.clone() else {
+        return Ok(());
+    };
+    let session_epoch = terminal.session_epoch();
+    let kind = terminal.kind();
+    match transport.send_peer_message(peer, terminal.to_message()) {
+        Ok(_) => {
+            execution.pending_terminal = None;
+            Ok(())
+        }
+        Err(err) if is_detached_backend_peer_error(&err) => {
+            warn!(
+                component = "worker",
+                session_epoch,
+                peer = ?peer,
+                error = %err,
+                terminal = kind,
+                "worker could not send terminal control because backend peer detached"
+            );
+            execution.pending_terminal = None;
+            Ok(())
+        }
+        Err(err) if is_worker_to_backend_ring_full_error(&err) => {
+            warn!(
+                component = "worker",
+                session_epoch,
+                peer = ?peer,
+                error = %err,
+                terminal = kind,
+                "worker terminal control ring is full; deferring terminal control"
+            );
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
 }
 
 fn handle_terminal_step(
@@ -994,6 +1624,15 @@ fn is_detached_backend_peer_error(err: &WorkerRuntimeError) -> bool {
         }
         _ => false,
     }
+}
+
+fn is_worker_to_backend_ring_full_error(err: &WorkerRuntimeError) -> bool {
+    matches!(
+        err,
+        WorkerRuntimeError::WorkerTx(control_transport::WorkerTxError::Ring(
+            control_transport::TxError::Full { .. }
+        ))
+    )
 }
 
 fn is_detached_slot_access_error(err: &control_transport::SlotAccessError) -> bool {
@@ -1081,6 +1720,1401 @@ fn truncate_utf8(value: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::alloc::{alloc_zeroed, dealloc, Layout};
+    use std::ptr::NonNull;
+    use std::sync::Once;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use control_transport::{TransportRegion, TransportRegionLayout};
+
+    #[derive(Debug)]
+    struct NoopScanSource;
+
+    impl ::worker::ScanBatchSource for NoopScanSource {
+        fn open_scan(
+            &self,
+            _request: ::worker::OpenScanRequest,
+        ) -> datafusion_common::Result<datafusion::physical_plan::SendableRecordBatchStream>
+        {
+            Err(datafusion_common::DataFusionError::Execution(
+                "test scan source is unused".into(),
+            ))
+        }
+    }
+
+    struct OwnedRegion {
+        base: NonNull<u8>,
+        layout: Layout,
+    }
+
+    impl OwnedRegion {
+        fn new(size: usize, align: usize) -> Self {
+            let layout = Layout::from_size_align(size, align).expect("layout");
+            let base = unsafe { alloc_zeroed(layout) };
+            let base = NonNull::new(base).expect("allocation");
+            Self { base, layout }
+        }
+    }
+
+    impl Drop for OwnedRegion {
+        fn drop(&mut self) {
+            unsafe { dealloc(self.base.as_ptr(), self.layout) };
+        }
+    }
+
+    struct TestTransport {
+        worker: TransportWorkerRuntime,
+        region: TransportRegion,
+        backend: BackendSlotLease,
+        _region_mem: OwnedRegion,
+    }
+
+    impl TestTransport {
+        fn new(worker_to_backend_capacity: usize) -> Self {
+            Self::with_slots(1, worker_to_backend_capacity)
+        }
+
+        fn with_slots(slot_count: u32, worker_to_backend_capacity: usize) -> Self {
+            ignore_sigusr1_for_tests();
+            let layout = TransportRegionLayout::new(slot_count, 256, worker_to_backend_capacity)
+                .expect("transport layout");
+            let worker_config = WorkerRuntimeConfig {
+                control_frame_capacity: worker_to_backend_capacity,
+                ..WorkerRuntimeConfig::default()
+            };
+            Self::with_layout_and_worker_config(layout, worker_config)
+        }
+
+        fn with_host_config(config: &crate::HostConfig) -> Self {
+            ignore_sigusr1_for_tests();
+            let layout = config.control_transport_layout().expect("transport layout");
+            Self::with_layout_and_worker_config(layout, config.worker_runtime_config())
+        }
+
+        fn with_layout_and_worker_config(
+            layout: TransportRegionLayout,
+            worker_config: WorkerRuntimeConfig,
+        ) -> Self {
+            let region_mem = OwnedRegion::new(layout.size, layout.align);
+            let region =
+                unsafe { TransportRegion::init_in_place(region_mem.base, layout.size, layout) }
+                    .expect("transport region");
+            let worker = TransportWorkerRuntime::attach(&region, &worker_config)
+                .expect("attach worker transport");
+            worker
+                .activate_generation(std::process::id() as i32)
+                .expect("activate worker generation");
+            let backend = BackendSlotLease::acquire(&region).expect("acquire backend lease");
+
+            Self {
+                worker,
+                region,
+                backend,
+                _region_mem: region_mem,
+            }
+        }
+
+        fn acquire_backend(&self) -> BackendSlotLease {
+            BackendSlotLease::acquire(&self.region).expect("acquire backend lease")
+        }
+
+        fn peer(&self) -> BackendLeaseSlot {
+            self.backend.backend_lease_slot()
+        }
+
+        fn recv_worker_execution(&mut self) -> protocol::WorkerExecutionToBackend {
+            recv_worker_execution_from(&mut self.backend)
+        }
+    }
+
+    fn send_backend_execution_frame(
+        backend: &mut BackendSlotLease,
+        message: protocol::BackendExecutionToWorker<'_>,
+    ) {
+        let mut buf = vec![0_u8; protocol::encoded_len_backend_execution_to_worker(message)];
+        let len = protocol::encode_backend_execution_to_worker_into(message, &mut buf)
+            .expect("encode backend execution frame");
+        let mut tx = backend.to_worker_tx();
+        tx.send_frame(&buf[..len]).expect("send backend frame");
+    }
+
+    fn recv_worker_execution_from(
+        backend: &mut BackendSlotLease,
+    ) -> protocol::WorkerExecutionToBackend {
+        let mut rx = backend.from_worker_rx();
+        let mut buf = vec![0_u8; 4096];
+        let len = rx
+            .recv_frame_into(&mut buf)
+            .expect("receive worker frame")
+            .expect("worker frame");
+        protocol::decode_worker_execution_to_backend(&buf[..len]).expect("decode worker frame")
+    }
+
+    fn drain_worker_execution_frames(
+        backend: &mut BackendSlotLease,
+    ) -> Vec<protocol::WorkerExecutionToBackend> {
+        let mut rx = backend.from_worker_rx();
+        let mut buf = vec![0_u8; 4096];
+        let mut frames = Vec::new();
+        while let Some(len) = rx.recv_frame_into(&mut buf).expect("receive worker frame") {
+            frames.push(
+                protocol::decode_worker_execution_to_backend(&buf[..len])
+                    .expect("decode worker frame"),
+            );
+        }
+        frames
+    }
+
+    fn fill_worker_to_backend_ring_until_full(
+        worker: &mut TransportWorkerRuntime,
+        peer: BackendLeaseSlot,
+    ) {
+        loop {
+            match worker.send_peer_message(peer, WorkerExecutionToBackend::ExecutionSlotReserved) {
+                Ok(_) => {}
+                Err(err) if is_worker_to_backend_ring_full_error(&err) => return,
+                Err(err) => panic!("unexpected worker-to-backend fill error: {err}"),
+            }
+        }
+    }
+
+    fn assert_fail_execution_frame(
+        frame: protocol::WorkerExecutionToBackend,
+        session_epoch: u64,
+        expected_detail: &str,
+    ) {
+        match frame {
+            protocol::WorkerExecutionToBackend::FailExecution {
+                session_epoch: actual_session_epoch,
+                code,
+                detail,
+            } => {
+                assert_eq!(actual_session_epoch, session_epoch);
+                assert_eq!(code, ExecutionFailureCode::Internal);
+                assert!(detail
+                    .as_deref()
+                    .is_some_and(|detail| detail.contains(expected_detail)));
+            }
+            other => panic!("unexpected worker frame: {other:?}"),
+        }
+    }
+
+    fn init_page_pool_for_test() -> (OwnedRegion, PagePool) {
+        let config = pool::PagePoolConfig::new(4096, 1).expect("page pool config");
+        let layout = PagePool::layout(config).expect("page pool layout");
+        let region = OwnedRegion::new(layout.size, layout.align);
+        let page_pool = unsafe { PagePool::init_in_place(region.base, layout.size, config) }
+            .expect("page pool init");
+        (region, page_pool)
+    }
+
+    fn init_issuance_pool_for_test() -> (OwnedRegion, IssuancePool) {
+        let config = issuance::IssuanceConfig::new(1).expect("issuance config");
+        let layout = IssuancePool::layout(config).expect("issuance layout");
+        let region = OwnedRegion::new(layout.size, layout.align);
+        let issuance_pool =
+            unsafe { IssuancePool::init_in_place(region.base, layout.size, config) }
+                .expect("issuance pool init");
+        (region, issuance_pool)
+    }
+
+    fn poll_test_execution_peer(
+        registry: &mut ExecutionRegistry,
+        worker: &mut TransportWorkerRuntime,
+        peer: BackendLeaseSlot,
+    ) {
+        let (_page_region, page_pool) = init_page_pool_for_test();
+        let (_issuance_region, issuance_pool) = init_issuance_pool_for_test();
+        let df_runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("create datafusion runtime");
+        let mut spill_runtime =
+            WorkerSpillRuntime::new(::worker::WorkerSpillConfig::default(), 123, 456)
+                .expect("create spill runtime");
+        let worker_config = WorkerRuntimeConfig::default();
+        let scan_source: Arc<dyn ::worker::ScanBatchSource> = Arc::new(NoopScanSource);
+        let wake = WorkerSchedulerWake::new().expect("create scheduler wake");
+        let (task_event_tx, _task_rx) = mpsc::channel(1);
+        let task_tx = WorkerTaskNotifier::new(task_event_tx, wake.sender());
+
+        poll_execution_peer(
+            registry,
+            worker,
+            &df_runtime,
+            &mut spill_runtime,
+            &test_host_config(4096),
+            &worker_config,
+            &scan_source,
+            &task_tx,
+            #[cfg(feature = "pg_test")]
+            crate::test_gate::attach(),
+            peer,
+            page_pool,
+            issuance_pool,
+            RuntimeMetrics::default(),
+        )
+        .expect("poll execution peer");
+    }
+
+    fn ignore_sigusr1_for_tests() {
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| unsafe {
+            libc::signal(libc::SIGUSR1, libc::SIG_IGN);
+        });
+    }
+
+    struct TestTempDir {
+        path: PathBuf,
+    }
+
+    impl TestTempDir {
+        fn new() -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "pg_fusion_worker_test_{}_{}",
+                std::process::id(),
+                unique
+            ));
+            std::fs::create_dir(&path).expect("create test temp dir");
+            Self { path }
+        }
+
+        fn path(&self) -> &std::path::Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestTempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn test_host_config(control_worker_to_backend_capacity: usize) -> crate::HostConfig {
+        crate::HostConfig {
+            enable: true,
+            worker_threads: Some(1),
+            log_path: "/tmp/pg_fusion.log".into(),
+            worker_log_filter: "warn".into(),
+            backend_log_level: backend_service::DiagnosticLogLevel::Basic,
+            worker_memory_limit_bytes: None,
+            worker_spill_directory: None,
+            max_fusion_tasks: 1,
+            control_slot_count: 1,
+            control_backend_to_worker_capacity: 256,
+            control_worker_to_backend_capacity,
+            scan_slot_count: 1,
+            scan_backend_to_worker_capacity: protocol::MIN_SCAN_BACKEND_TO_WORKER_RING_CAPACITY,
+            scan_worker_to_backend_capacity: protocol::MIN_SCAN_WORKER_TO_BACKEND_RING_CAPACITY,
+            page_size: 4096,
+            page_count: 4,
+            scan_fetch_batch_rows: 16,
+            scan_batch_channel_capacity: 1,
+            scan_idle_poll_interval_us: 50,
+            estimator_initial_tail_bytes_per_row: 64,
+            join_reordering: false,
+            runtime_filter_enable: true,
+            runtime_filter_count: 1,
+            runtime_filter_bits: 1024,
+            runtime_filter_hashes: 1,
+        }
+    }
+
+    fn test_peer(slot_id: u32) -> BackendLeaseSlot {
+        test_peer_incarnation(slot_id, u64::from(slot_id) + 1)
+    }
+
+    fn test_peer_incarnation(slot_id: u32, lease_epoch: u64) -> BackendLeaseSlot {
+        BackendLeaseSlot::new(
+            slot_id,
+            control_transport::BackendLeaseId::new(1, lease_epoch),
+        )
+    }
+
+    fn test_execution() -> ActiveWorkerExecution {
+        ActiveWorkerExecution::new(
+            WorkerRuntimeConfig::default(),
+            std::sync::Arc::new(NoopScanSource),
+        )
+    }
+
+    fn test_plan_descriptor(plan_id: u64) -> protocol::PlanFlowDescriptor {
+        protocol::PlanFlowDescriptor {
+            plan_id,
+            page_kind: 0x504c,
+            page_flags: 0,
+        }
+    }
+
+    fn start_test_execution(
+        execution: &mut ActiveWorkerExecution,
+        peer: BackendLeaseSlot,
+        session_epoch: u64,
+    ) {
+        execution
+            .runtime
+            .accept_backend_control(
+                peer,
+                protocol::BackendExecutionToWorkerRef::StartExecution {
+                    session_epoch,
+                    plan: test_plan_descriptor(1),
+                    options: protocol::ExecutionOptionsWire::default(),
+                    scans: protocol::ScanChannelSetRef::empty(),
+                },
+            )
+            .expect("start test execution");
+    }
+
+    fn test_empty_logical_plan() -> datafusion::logical_expr::LogicalPlan {
+        datafusion::logical_expr::LogicalPlan::EmptyRelation(
+            datafusion::logical_expr::logical_plan::EmptyRelation {
+                produce_one_row: false,
+                schema: Arc::new(datafusion_common::DFSchema::empty()),
+            },
+        )
+    }
+
+    fn start_planning_test_execution(
+        execution: &mut ActiveWorkerExecution,
+        peer: BackendLeaseSlot,
+        session_epoch: u64,
+    ) -> Box<::worker::PendingPhysicalPlanning> {
+        start_test_execution(execution, peer, session_epoch);
+
+        let (_page_region, page_pool) = init_page_pool_for_test();
+        let (_issuance_region, issuance_pool) = init_issuance_pool_for_test();
+        let tx = IssuedTx::new(PageTx::new(page_pool), issuance_pool);
+        let rx = IssuedRx::new(transfer::PageRx::new(page_pool), issuance_pool);
+        let plan_descriptor = test_plan_descriptor(1);
+        let flow = plan_flow::FlowId {
+            session_epoch,
+            plan_id: plan_descriptor.plan_id,
+        };
+        let open =
+            plan_flow::PlanOpen::new(flow, plan_descriptor.page_kind, plan_descriptor.page_flags);
+        let plan = test_empty_logical_plan();
+        let mut backend = plan_flow::BackendPlanRole::new(tx);
+        backend.open(open, &plan).expect("open test plan flow");
+
+        loop {
+            match backend.step().expect("step test plan flow") {
+                plan_flow::BackendPlanStep::OutboundPage { flow, outbound } => {
+                    let frame = outbound.frame();
+                    outbound.mark_sent();
+                    assert!(matches!(
+                        execution
+                            .runtime
+                            .accept_issued_plan_frame(peer, &rx, &frame)
+                            .expect("accept plan page"),
+                        WorkerRuntimeStep::PlanFrameAccepted { .. }
+                    ));
+                    assert_eq!(flow.session_epoch, session_epoch);
+                }
+                plan_flow::BackendPlanStep::CloseFrame { flow, frame } => {
+                    let step = execution
+                        .runtime
+                        .accept_issued_plan_frame(peer, &rx, &frame)
+                        .expect("accept plan close");
+                    let WorkerRuntimeStep::PlanningStarted(pending) = step else {
+                        panic!("expected planning start, got {step:?}");
+                    };
+                    assert_eq!(pending.flow(), flow);
+                    backend.close().expect("close test plan flow");
+                    return pending;
+                }
+                plan_flow::BackendPlanStep::Blocked { .. } => {
+                    panic!("test plan flow unexpectedly blocked")
+                }
+                plan_flow::BackendPlanStep::LogicalError { message, .. } => {
+                    panic!("test plan flow failed: {message}")
+                }
+            }
+        }
+    }
+
+    fn start_running_test_execution(
+        execution: &mut ActiveWorkerExecution,
+        peer: BackendLeaseSlot,
+        session_epoch: u64,
+    ) {
+        let pending = start_planning_test_execution(execution, peer, session_epoch);
+        let flow = pending.flow();
+        let plan = futures::executor::block_on(pending.plan()).expect("build test physical plan");
+        let (step, planning_err) = execution
+            .runtime
+            .finish_physical_planning_step(peer, flow, Ok(plan))
+            .expect("finish test physical planning");
+        assert!(planning_err.is_none());
+        assert!(matches!(step, WorkerRuntimeStep::PhysicalPlanReady(_)));
+        assert_eq!(
+            execution.runtime.state(),
+            ::worker::fsm::WorkerExecutionState::Running
+        );
+    }
+
+    fn retained_idle_execution(peer: BackendLeaseSlot) -> ActiveWorkerExecution {
+        let mut execution = test_execution();
+        start_test_execution(&mut execution, peer, 10);
+        let step = execution
+            .runtime
+            .accept_backend_control(
+                peer,
+                protocol::BackendExecutionToWorkerRef::CancelExecution { session_epoch: 10 },
+            )
+            .expect("cancel test execution");
+        handle_terminal_step(&mut execution, step).expect("cleanup terminal execution");
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        execution
+    }
+
+    #[test]
+    fn execution_registry_counts_only_active_entries() {
+        let peer = test_peer(1);
+        let mut registry = ExecutionRegistry::with_capacity(4);
+        let mut execution = test_execution();
+        start_test_execution(&mut execution, peer, 10);
+
+        registry.retain_after_poll(peer, execution);
+        assert_eq!(registry.active_len(), 1);
+        assert!(registry.contains_active(peer));
+        assert!(registry.entries.capacity() >= 4);
+        assert!(registry.active_peers.capacity() >= 4);
+
+        let mut execution = registry.remove(peer).expect("active entry");
+        assert_eq!(registry.active_len(), 0);
+        let step = execution
+            .runtime
+            .accept_backend_control(
+                peer,
+                protocol::BackendExecutionToWorkerRef::CancelExecution { session_epoch: 10 },
+            )
+            .expect("cancel active execution");
+        handle_terminal_step(&mut execution, step).expect("cleanup terminal execution");
+
+        registry.retain_after_poll(peer, execution);
+        assert_eq!(registry.active_len(), 0);
+        assert!(!registry.contains_active(peer));
+        assert!(registry.entries.contains_key(&peer));
+    }
+
+    #[test]
+    fn execution_registry_retained_entries_do_not_consume_active_capacity() {
+        let retained_peer = test_peer(1);
+        let active_peer = test_peer(2);
+        let mut registry = ExecutionRegistry::with_capacity(2);
+
+        registry.retain_after_poll(retained_peer, retained_idle_execution(retained_peer));
+        assert_eq!(registry.active_len(), 0);
+        assert!(!registry.contains_active(retained_peer));
+
+        let mut active = test_execution();
+        start_test_execution(&mut active, active_peer, 20);
+        registry.retain_after_poll(active_peer, active);
+
+        assert_eq!(registry.active_len(), 1);
+        assert!(registry.contains_active(active_peer));
+        assert!(registry.entries.contains_key(&retained_peer));
+    }
+
+    #[test]
+    fn execution_registry_can_evict_retained_idle_entries() {
+        let peer = test_peer(1);
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        registry.retain_after_poll(peer, retained_idle_execution(peer));
+
+        let execution = registry.remove(peer).expect("retained entry");
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        assert_eq!(registry.active_len(), 0);
+        assert!(!registry.entries.contains_key(&peer));
+    }
+
+    #[test]
+    fn execution_registry_bounds_retained_entries_by_slot_id() {
+        let old_peer = test_peer_incarnation(1, 2);
+        let new_peer = test_peer_incarnation(1, 3);
+        let mut registry = ExecutionRegistry::with_capacity(1);
+
+        registry.retain_after_poll(old_peer, retained_idle_execution(old_peer));
+        registry.retain_after_poll(new_peer, retained_idle_execution(new_peer));
+
+        assert_eq!(registry.active_len(), 0);
+        assert_eq!(registry.entries.len(), 1);
+        assert!(!registry.entries.contains_key(&old_peer));
+        assert!(registry.entries.contains_key(&new_peer));
+        assert_eq!(registry.retained_by_slot.get(&1), Some(&new_peer));
+    }
+
+    #[test]
+    fn execution_registry_active_peer_evicts_retained_entry_for_same_slot() {
+        let retained_peer = test_peer_incarnation(1, 2);
+        let active_peer = test_peer_incarnation(1, 3);
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        registry.retain_after_poll(retained_peer, retained_idle_execution(retained_peer));
+
+        let mut active = test_execution();
+        start_test_execution(&mut active, active_peer, 20);
+        registry.retain_after_poll(active_peer, active);
+
+        assert_eq!(registry.active_len(), 1);
+        assert!(registry.contains_active(active_peer));
+        assert!(!registry.entries.contains_key(&retained_peer));
+        assert!(!registry.retained_by_slot.contains_key(&1));
+    }
+
+    #[test]
+    fn retained_cancel_routes_through_runtime_polling() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        registry.retain_after_poll(peer, retained_idle_execution(peer));
+        assert_eq!(
+            registry.peer_scheduler_state(peer),
+            PeerSchedulerState::Retained
+        );
+
+        send_backend_execution_frame(
+            &mut transport.backend,
+            protocol::BackendExecutionToWorker::CancelExecution { session_epoch: 10 },
+        );
+        poll_test_execution_peer(&mut registry, &mut transport.worker, peer);
+
+        assert_eq!(
+            registry.peer_scheduler_state(peer),
+            PeerSchedulerState::Retained
+        );
+        assert!(registry.entries.contains_key(&peer));
+    }
+
+    #[test]
+    fn retained_fail_routes_through_runtime_polling() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        registry.retain_after_poll(peer, retained_idle_execution(peer));
+        assert_eq!(
+            registry.peer_scheduler_state(peer),
+            PeerSchedulerState::Retained
+        );
+
+        send_backend_execution_frame(
+            &mut transport.backend,
+            protocol::BackendExecutionToWorker::FailExecution {
+                session_epoch: 10,
+                code: ExecutionFailureCode::Internal,
+                detail: None,
+            },
+        );
+        poll_test_execution_peer(&mut registry, &mut transport.worker, peer);
+
+        assert_eq!(
+            registry.peer_scheduler_state(peer),
+            PeerSchedulerState::Retained
+        );
+        assert!(registry.entries.contains_key(&peer));
+    }
+
+    #[test]
+    fn retained_cancel_reservation_preserves_pending_terminal() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        let mut execution = retained_idle_execution(peer);
+        execution.pending_terminal = Some(PendingTerminalControl::Fail {
+            session_epoch: 10,
+            code: ExecutionFailureCode::Internal,
+            detail: Some("deferred failure".into()),
+        });
+        registry.retain_after_poll(peer, execution);
+        assert_eq!(
+            registry.peer_scheduler_state(peer),
+            PeerSchedulerState::Retained
+        );
+
+        send_backend_execution_frame(
+            &mut transport.backend,
+            protocol::BackendExecutionToWorker::CancelExecutionReservation,
+        );
+        poll_test_execution_peer(&mut registry, &mut transport.worker, peer);
+
+        let execution = registry.entries.get(&peer).expect("retained execution");
+        assert_eq!(
+            registry.peer_scheduler_state(peer),
+            PeerSchedulerState::Retained
+        );
+        assert_eq!(
+            execution.pending_terminal,
+            Some(PendingTerminalControl::Fail {
+                session_epoch: 10,
+                code: ExecutionFailureCode::Internal,
+                detail: Some("deferred failure".into()),
+            })
+        );
+        assert!(drain_worker_execution_frames(&mut transport.backend).is_empty());
+    }
+
+    #[test]
+    fn execution_reservation_counts_until_start_becomes_active() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        let mut registry = ExecutionRegistry::with_capacity(1);
+
+        assert!(
+            grant_execution_reservation(&mut registry, &mut transport.worker, peer)
+                .expect("grant reservation")
+        );
+        assert!(registry.contains_reserved(peer));
+        assert_eq!(registry.admitted_len(), 1);
+        assert_eq!(
+            transport.recv_worker_execution(),
+            protocol::WorkerExecutionToBackend::ExecutionSlotReserved
+        );
+
+        let mut execution = test_execution();
+        start_test_execution(&mut execution, peer, 10);
+        registry.retain_after_poll(peer, execution);
+
+        assert!(!registry.contains_reserved(peer));
+        assert!(registry.contains_active(peer));
+        assert_eq!(registry.admitted_len(), 1);
+    }
+
+    #[test]
+    fn queued_execution_reservation_grants_after_active_slot_frees() {
+        let mut transport = TestTransport::with_slots(2, 4096);
+        let active_peer = transport.peer();
+        let mut queued_backend = transport.acquire_backend();
+        let queued_peer = queued_backend.backend_lease_slot();
+        let mut registry = ExecutionRegistry::with_capacity(2);
+
+        let mut active = test_execution();
+        start_test_execution(&mut active, active_peer, 10);
+        registry.retain_after_poll(active_peer, active);
+        registry.queue_reservation(queued_peer);
+
+        grant_queued_execution_reservations(&mut registry, &mut transport.worker, 1)
+            .expect("capacity full keeps reservation queued");
+        assert!(registry.contains_queued(queued_peer));
+        assert_eq!(registry.admitted_len(), 1);
+
+        let mut active = registry.remove(active_peer).expect("active execution");
+        let step = active
+            .runtime
+            .accept_backend_control(
+                active_peer,
+                protocol::BackendExecutionToWorkerRef::CancelExecution { session_epoch: 10 },
+            )
+            .expect("cancel active execution");
+        handle_terminal_step(&mut active, step).expect("cleanup active execution");
+        registry.retain_after_poll(active_peer, active);
+
+        grant_queued_execution_reservations(&mut registry, &mut transport.worker, 1)
+            .expect("free capacity grants queued reservation");
+        assert!(!registry.contains_queued(queued_peer));
+        assert!(registry.contains_reserved(queued_peer));
+        assert_eq!(
+            recv_worker_execution_from(&mut queued_backend),
+            protocol::WorkerExecutionToBackend::ExecutionSlotReserved
+        );
+    }
+
+    #[test]
+    fn new_reservation_request_waits_behind_existing_queue() {
+        let mut transport = TestTransport::with_slots(2, 4096);
+        let mut newer_backend = transport.acquire_backend();
+        let mut older_backend = transport.backend;
+        let older_peer = older_backend.backend_lease_slot();
+        let newer_peer = newer_backend.backend_lease_slot();
+        let mut registry = ExecutionRegistry::with_capacity(2);
+
+        registry.queue_reservation(older_peer);
+        handle_requested_execution_reservation(&mut registry, &mut transport.worker, newer_peer, 1)
+            .expect("new request is admitted into queue");
+
+        assert!(registry.contains_queued(older_peer));
+        assert!(registry.contains_queued(newer_peer));
+        assert!(!registry.contains_reserved(newer_peer));
+
+        grant_queued_execution_reservations(&mut registry, &mut transport.worker, 1)
+            .expect("grant queued reservation");
+
+        assert!(registry.contains_reserved(older_peer));
+        assert!(registry.contains_queued(newer_peer));
+        assert!(!registry.contains_reserved(newer_peer));
+        assert_eq!(
+            recv_worker_execution_from(&mut older_backend),
+            protocol::WorkerExecutionToBackend::ExecutionSlotReserved
+        );
+        let mut scratch = vec![0_u8; 4096];
+        assert!(newer_backend
+            .from_worker_rx()
+            .recv_frame_into(&mut scratch)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn detached_reserved_peer_releases_admission_slot() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        let mut registry = ExecutionRegistry::with_capacity(1);
+
+        assert!(
+            grant_execution_reservation(&mut registry, &mut transport.worker, peer)
+                .expect("grant reservation")
+        );
+        assert_eq!(
+            transport.recv_worker_execution(),
+            protocol::WorkerExecutionToBackend::ExecutionSlotReserved
+        );
+        assert!(registry.contains_reserved(peer));
+
+        let TestTransport {
+            mut worker,
+            backend,
+            region: _region,
+            _region_mem,
+        } = transport;
+        drop(backend);
+
+        let (_page_region, page_pool) = init_page_pool_for_test();
+        let (_issuance_region, issuance_pool) = init_issuance_pool_for_test();
+        let df_runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("create datafusion runtime");
+        let mut spill_runtime =
+            WorkerSpillRuntime::new(::worker::WorkerSpillConfig::default(), 123, 456)
+                .expect("create spill runtime");
+        let worker_config = WorkerRuntimeConfig::default();
+        let scan_source: Arc<dyn ::worker::ScanBatchSource> = Arc::new(NoopScanSource);
+        let wake = WorkerSchedulerWake::new().expect("create scheduler wake");
+        let (task_event_tx, _task_rx) = mpsc::channel(1);
+        let task_tx = WorkerTaskNotifier::new(task_event_tx, wake.sender());
+
+        poll_execution_peer(
+            &mut registry,
+            &mut worker,
+            &df_runtime,
+            &mut spill_runtime,
+            &test_host_config(4096),
+            &worker_config,
+            &scan_source,
+            &task_tx,
+            #[cfg(feature = "pg_test")]
+            crate::test_gate::attach(),
+            peer,
+            page_pool,
+            issuance_pool,
+            RuntimeMetrics::default(),
+        )
+        .expect("poll detached reserved peer");
+
+        assert!(!registry.contains_reserved(peer));
+        assert_eq!(registry.admitted_len(), 0);
+    }
+
+    #[test]
+    fn admission_request_reads_reserve_and_cancel_messages() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+
+        send_backend_execution_frame(
+            &mut transport.backend,
+            protocol::BackendExecutionToWorker::ReserveExecutionSlot,
+        );
+        assert!(matches!(
+            recv_backend_admission_request(&mut transport.worker, peer),
+            Ok(AdmissionPollOutcome::Requested)
+        ));
+
+        send_backend_execution_frame(
+            &mut transport.backend,
+            protocol::BackendExecutionToWorker::CancelExecutionReservation,
+        );
+        assert!(matches!(
+            recv_backend_admission_request(&mut transport.worker, peer),
+            Ok(AdmissionPollOutcome::Cancelled)
+        ));
+    }
+
+    #[test]
+    fn admission_request_rejects_start_before_reservation_grant() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        send_backend_execution_frame(
+            &mut transport.backend,
+            protocol::BackendExecutionToWorker::StartExecution {
+                session_epoch: 10,
+                plan: test_plan_descriptor(1),
+                options: protocol::ExecutionOptionsWire::default(),
+                scans: protocol::ScanChannelSet::empty(),
+            },
+        );
+
+        let err = recv_backend_admission_request(&mut transport.worker, peer)
+            .expect_err("start before grant must fail");
+        assert!(
+            err.to_string()
+                .contains("before execution reservation was granted"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn reserved_peer_cancel_reservation_before_start_releases_admission_slot() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        let mut registry = ExecutionRegistry::with_capacity(1);
+
+        assert!(
+            grant_execution_reservation(&mut registry, &mut transport.worker, peer)
+                .expect("grant reservation")
+        );
+        assert_eq!(
+            transport.recv_worker_execution(),
+            protocol::WorkerExecutionToBackend::ExecutionSlotReserved
+        );
+        assert!(registry.contains_reserved(peer));
+
+        send_backend_execution_frame(
+            &mut transport.backend,
+            protocol::BackendExecutionToWorker::CancelExecutionReservation,
+        );
+        poll_test_execution_peer(&mut registry, &mut transport.worker, peer);
+
+        assert!(!registry.contains_reserved(peer));
+        assert_eq!(registry.admitted_len(), 0);
+        assert!(!registry.entries.contains_key(&peer));
+    }
+
+    #[test]
+    fn active_receiving_plan_cancel_reservation_reports_failed_execution() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        let mut execution = test_execution();
+        start_test_execution(&mut execution, peer, 10);
+        registry.retain_after_poll(peer, execution);
+
+        send_backend_execution_frame(
+            &mut transport.backend,
+            protocol::BackendExecutionToWorker::CancelExecutionReservation,
+        );
+        poll_test_execution_peer(&mut registry, &mut transport.worker, peer);
+
+        let execution = registry.entries.get(&peer).expect("retained execution");
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        assert!(execution.pending_terminal.is_none());
+        assert!(!registry.contains_active(peer));
+        assert_fail_execution_frame(
+            transport.recv_worker_execution(),
+            10,
+            "CancelExecutionReservation after execution started",
+        );
+    }
+
+    #[test]
+    fn active_running_cancel_reservation_aborts_task_and_reports_failure() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        let df_runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("create datafusion runtime");
+        let mut execution = test_execution();
+        start_running_test_execution(&mut execution, peer, 10);
+        execution.task = Some(df_runtime.spawn(async {
+            std::future::pending::<()>().await;
+        }));
+        registry.retain_after_poll(peer, execution);
+
+        send_backend_execution_frame(
+            &mut transport.backend,
+            protocol::BackendExecutionToWorker::CancelExecutionReservation,
+        );
+        poll_test_execution_peer(&mut registry, &mut transport.worker, peer);
+
+        let execution = registry.entries.get(&peer).expect("retained execution");
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        assert!(execution.task.is_none());
+        assert!(execution.pending_terminal.is_none());
+        assert!(!registry.contains_active(peer));
+        assert_fail_execution_frame(
+            transport.recv_worker_execution(),
+            10,
+            "CancelExecutionReservation after execution started",
+        );
+    }
+
+    #[test]
+    fn active_cancel_reservation_failure_defers_when_terminal_ring_is_full() {
+        let mut transport = TestTransport::new(256);
+        let peer = transport.peer();
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        let mut execution = test_execution();
+        start_running_test_execution(&mut execution, peer, 10);
+        registry.retain_after_poll(peer, execution);
+        fill_worker_to_backend_ring_until_full(&mut transport.worker, peer);
+
+        send_backend_execution_frame(
+            &mut transport.backend,
+            protocol::BackendExecutionToWorker::CancelExecutionReservation,
+        );
+        poll_test_execution_peer(&mut registry, &mut transport.worker, peer);
+
+        let execution = registry.entries.get(&peer).expect("retained execution");
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        assert!(!registry.contains_active(peer));
+        assert!(matches!(
+            execution.pending_terminal,
+            Some(PendingTerminalControl::Fail {
+                session_epoch: 10,
+                code: ExecutionFailureCode::Internal,
+                ..
+            })
+        ));
+
+        let filled = drain_worker_execution_frames(&mut transport.backend);
+        assert!(!filled.is_empty());
+        assert!(filled
+            .iter()
+            .all(|frame| matches!(frame, WorkerExecutionToBackend::ExecutionSlotReserved)));
+
+        let mut execution = registry.remove(peer).expect("retained execution");
+        retry_pending_terminal_control(&mut transport.worker, &mut execution, peer)
+            .expect("retry pending failure after drain");
+        assert!(execution.pending_terminal.is_none());
+        registry.retain_after_poll(peer, execution);
+
+        assert_fail_execution_frame(
+            transport.recv_worker_execution(),
+            10,
+            "CancelExecutionReservation after execution started",
+        );
+    }
+
+    #[test]
+    fn execution_registry_removes_only_matching_active_terminal_task_event() {
+        let peer = test_peer(1);
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        let mut execution = test_execution();
+        start_test_execution(&mut execution, peer, 10);
+        registry.retain_after_poll(peer, execution);
+
+        assert!(registry.remove_active_session(peer, 11).is_none());
+        assert_eq!(registry.active_len(), 1);
+        assert!(registry.entries.contains_key(&peer));
+
+        let removed = registry
+            .remove_active_session(peer, 10)
+            .expect("matching active session");
+        assert_eq!(removed.runtime.active_peer(), Some(peer));
+        assert_eq!(registry.active_len(), 0);
+        assert!(!registry.entries.contains_key(&peer));
+    }
+
+    #[test]
+    fn execution_registry_ignores_retained_terminal_task_event() {
+        let peer = test_peer(1);
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        registry.retain_after_poll(peer, retained_idle_execution(peer));
+
+        assert!(registry.remove_active_session(peer, 10).is_none());
+        assert_eq!(registry.active_len(), 0);
+        assert!(registry.entries.contains_key(&peer));
+        assert_eq!(registry.retained_by_slot.get(&peer.slot_id()), Some(&peer));
+    }
+
+    #[test]
+    fn stale_physical_planning_result_preserves_current_task_handle() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        let df_runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("create datafusion runtime");
+        let mut execution = test_execution();
+        start_test_execution(&mut execution, peer, 11);
+        execution.task = Some(df_runtime.spawn(async {
+            std::future::pending::<()>().await;
+        }));
+        registry.retain_after_poll(peer, execution);
+
+        let (_page_region, page_pool) = init_page_pool_for_test();
+        let (_issuance_region, issuance_pool) = init_issuance_pool_for_test();
+        let mut spill_runtime =
+            WorkerSpillRuntime::new(::worker::WorkerSpillConfig::default(), 123, 456)
+                .expect("create spill runtime");
+        let wake = WorkerSchedulerWake::new().expect("create scheduler wake");
+        let (task_event_tx, _task_rx) = mpsc::channel(1);
+        let task_tx = WorkerTaskNotifier::new(task_event_tx, wake.sender());
+
+        handle_task_event(
+            &mut registry,
+            &mut transport.worker,
+            &df_runtime,
+            &mut spill_runtime,
+            &test_host_config(4096),
+            page_pool,
+            issuance_pool,
+            RuntimeMetrics::default(),
+            &task_tx,
+            #[cfg(feature = "pg_test")]
+            crate::test_gate::attach(),
+            WorkerTaskEvent::PhysicalPlanningFinished {
+                peer,
+                flow: plan_flow::FlowId {
+                    session_epoch: 10,
+                    plan_id: 1,
+                },
+                result: Err(protocol_error("stale planning result")),
+            },
+        )
+        .expect("stale planning result is ignored");
+
+        let execution = registry.entries.get(&peer).expect("current execution");
+        assert!(registry.contains_active(peer));
+        assert!(execution.task.is_some());
+
+        let mut execution = registry.remove(peer).expect("current execution");
+        execution.abort_task();
+    }
+
+    #[test]
+    fn active_physical_planning_failure_reports_failed_execution() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        let mut registry = ExecutionRegistry::with_capacity(1);
+        let df_runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("create datafusion runtime");
+        let mut execution = test_execution();
+        let pending = start_planning_test_execution(&mut execution, peer, 10);
+        let flow = pending.flow();
+        drop(pending);
+        registry.retain_after_poll(peer, execution);
+
+        let (_page_region, page_pool) = init_page_pool_for_test();
+        let (_issuance_region, issuance_pool) = init_issuance_pool_for_test();
+        let mut spill_runtime =
+            WorkerSpillRuntime::new(::worker::WorkerSpillConfig::default(), 123, 456)
+                .expect("create spill runtime");
+        let wake = WorkerSchedulerWake::new().expect("create scheduler wake");
+        let (task_event_tx, _task_rx) = mpsc::channel(1);
+        let task_tx = WorkerTaskNotifier::new(task_event_tx, wake.sender());
+
+        handle_task_event(
+            &mut registry,
+            &mut transport.worker,
+            &df_runtime,
+            &mut spill_runtime,
+            &test_host_config(4096),
+            page_pool,
+            issuance_pool,
+            RuntimeMetrics::default(),
+            &task_tx,
+            #[cfg(feature = "pg_test")]
+            crate::test_gate::attach(),
+            WorkerTaskEvent::PhysicalPlanningFinished {
+                peer,
+                flow,
+                result: Err(protocol_error("physical planning failed for test")),
+            },
+        )
+        .expect("planning failure is reported to backend");
+
+        let execution = registry.entries.get(&peer).expect("retained execution");
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        assert!(execution.pending_terminal.is_none());
+        assert!(!registry.contains_active(peer));
+
+        match transport.recv_worker_execution() {
+            WorkerExecutionToBackend::FailExecution {
+                session_epoch,
+                code,
+                detail,
+            } => {
+                assert_eq!(session_epoch, 10);
+                assert_eq!(code, ExecutionFailureCode::Internal);
+                assert!(detail
+                    .as_deref()
+                    .is_some_and(|detail| detail.contains("physical planning failed for test")));
+            }
+            other => panic!("unexpected worker frame: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn execution_spill_dir_failure_reports_failed_execution() {
+        let mut transport = TestTransport::new(4096);
+        let peer = transport.peer();
+        let mut execution = test_execution();
+        start_test_execution(&mut execution, peer, 10);
+        execution.worker_start_ns = Some(RuntimeMetrics::default().now_ns());
+
+        let tmp = TestTempDir::new();
+        let spill_config =
+            ::worker::WorkerSpillConfig::new(Some(1024 * 1024), Some(tmp.path().to_path_buf()));
+        let mut spill_runtime =
+            WorkerSpillRuntime::new(spill_config, 123, 456).expect("create spill runtime");
+        let active_dir = spill_runtime
+            .active_dir()
+            .expect("active spill dir")
+            .to_path_buf();
+        std::fs::remove_dir_all(&active_dir).expect("remove active spill dir");
+        std::fs::write(&active_dir, b"not a directory").expect("replace active dir with file");
+
+        let result = execution_spill_dir_or_fail(
+            &mut transport.worker,
+            &mut execution,
+            &mut spill_runtime,
+            &test_host_config(4096),
+            RuntimeMetrics::default(),
+            peer,
+            10,
+        )
+        .expect("spill dir failure is contained");
+
+        assert!(result.is_none());
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        let frame = transport.recv_worker_execution();
+        match frame {
+            protocol::WorkerExecutionToBackend::FailExecution {
+                session_epoch,
+                code,
+                detail,
+            } => {
+                assert_eq!(session_epoch, 10);
+                assert_eq!(code, ExecutionFailureCode::Internal);
+                assert!(detail
+                    .as_deref()
+                    .is_some_and(|detail| detail.contains("create execution spill directory")));
+            }
+            other => panic!("unexpected worker frame: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn complete_execution_terminal_send_full_defers_and_retries() {
+        let mut transport = TestTransport::new(128);
+        let peer = transport.peer();
+        fill_worker_to_backend_ring_until_full(&mut transport.worker, peer);
+
+        let mut execution = test_execution();
+        start_running_test_execution(&mut execution, peer, 10);
+        finish_execution_task(
+            &mut transport.worker,
+            &mut execution,
+            &test_host_config(128),
+            RuntimeMetrics::default(),
+            peer,
+            10,
+            Ok(()),
+        )
+        .expect("full terminal ring should defer complete");
+
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        assert_eq!(
+            execution.pending_terminal,
+            Some(PendingTerminalControl::Complete { session_epoch: 10 })
+        );
+
+        let filled = drain_worker_execution_frames(&mut transport.backend);
+        assert!(!filled.is_empty());
+        assert!(filled
+            .iter()
+            .all(|frame| matches!(frame, WorkerExecutionToBackend::ExecutionSlotReserved)));
+
+        retry_pending_terminal_control(&mut transport.worker, &mut execution, peer)
+            .expect("retry complete after drain");
+        assert!(execution.pending_terminal.is_none());
+        assert_eq!(
+            transport.recv_worker_execution(),
+            WorkerExecutionToBackend::CompleteExecution { session_epoch: 10 }
+        );
+    }
+
+    #[test]
+    fn fail_execution_terminal_send_full_defers_and_retries_with_detail() {
+        let mut transport = TestTransport::new(256);
+        let peer = transport.peer();
+        fill_worker_to_backend_ring_until_full(&mut transport.worker, peer);
+
+        let mut execution = test_execution();
+        start_test_execution(&mut execution, peer, 10);
+        finish_execution_task(
+            &mut transport.worker,
+            &mut execution,
+            &test_host_config(256),
+            RuntimeMetrics::default(),
+            peer,
+            10,
+            Err(protocol_error("deferred terminal failure")),
+        )
+        .expect("full terminal ring should defer failure");
+
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        assert!(matches!(
+            execution.pending_terminal,
+            Some(PendingTerminalControl::Fail {
+                session_epoch: 10,
+                code: ExecutionFailureCode::Internal,
+                ..
+            })
+        ));
+
+        let filled = drain_worker_execution_frames(&mut transport.backend);
+        assert!(!filled.is_empty());
+        retry_pending_terminal_control(&mut transport.worker, &mut execution, peer)
+            .expect("retry failure after drain");
+        assert!(execution.pending_terminal.is_none());
+
+        match transport.recv_worker_execution() {
+            WorkerExecutionToBackend::FailExecution {
+                session_epoch,
+                code,
+                detail,
+            } => {
+                assert_eq!(session_epoch, 10);
+                assert_eq!(code, ExecutionFailureCode::Internal);
+                assert!(detail
+                    .as_deref()
+                    .is_some_and(|detail| detail.contains("deferred terminal failure")));
+            }
+            other => panic!("unexpected worker frame: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn worker_failure_detail_fits_asymmetric_primary_control_scratch() {
+        let config = test_host_config(4096);
+        assert!(
+            config.control_backend_to_worker_capacity < config.control_worker_to_backend_capacity
+        );
+        let mut transport = TestTransport::with_host_config(&config);
+        let peer = transport.peer();
+        let mut execution = test_execution();
+        start_test_execution(&mut execution, peer, 10);
+
+        let detail = "asymmetric worker scratch execution failure ".repeat(128);
+        finish_execution_task(
+            &mut transport.worker,
+            &mut execution,
+            &config,
+            RuntimeMetrics::default(),
+            peer,
+            10,
+            Err(protocol_error(&detail)),
+        )
+        .expect("worker failure detail should fit resized scratch");
+
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        assert_fail_execution_frame(
+            transport.recv_worker_execution(),
+            10,
+            "asymmetric worker scratch execution failure",
+        );
+    }
+
+    #[test]
+    fn planning_failure_detail_fits_asymmetric_primary_control_scratch() {
+        let config = test_host_config(4096);
+        assert!(
+            config.control_backend_to_worker_capacity < config.control_worker_to_backend_capacity
+        );
+        let mut transport = TestTransport::with_host_config(&config);
+        let peer = transport.peer();
+        let mut execution = test_execution();
+        let pending = start_planning_test_execution(&mut execution, peer, 10);
+        let flow = pending.flow();
+        drop(pending);
+
+        let detail = "asymmetric worker scratch planning failure ".repeat(128);
+        let (step, planning_err) = execution
+            .runtime
+            .finish_physical_planning_step(peer, flow, Err(protocol_error(&detail)))
+            .expect("finish failed physical planning");
+        let err = planning_err.expect("planning error");
+
+        finish_failed_terminal_step(
+            &mut transport.worker,
+            &mut execution,
+            &config,
+            peer,
+            err,
+            step,
+        )
+        .expect("planning failure detail should fit resized scratch");
+
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        assert_fail_execution_frame(
+            transport.recv_worker_execution(),
+            10,
+            "asymmetric worker scratch planning failure",
+        );
+    }
+
+    #[test]
+    fn detached_terminal_send_cleans_without_pending_retry() {
+        let mut transport = TestTransport::new(128);
+        let peer = transport.peer();
+        transport.backend.release();
+
+        let mut execution = test_execution();
+        start_running_test_execution(&mut execution, peer, 10);
+        finish_execution_task(
+            &mut transport.worker,
+            &mut execution,
+            &test_host_config(128),
+            RuntimeMetrics::default(),
+            peer,
+            10,
+            Ok(()),
+        )
+        .expect("detached terminal peer should be contained");
+
+        assert_eq!(execution.runtime.active_peer(), None);
+        assert_eq!(execution.runtime.retained_peer(), Some(peer));
+        assert!(execution.pending_terminal.is_none());
+    }
+
+    #[test]
+    fn terminal_send_config_error_remains_fatal() {
+        let mut transport = TestTransport::new(5);
+        let peer = transport.peer();
+        let mut execution = test_execution();
+        start_running_test_execution(&mut execution, peer, 10);
+
+        let err = finish_execution_task(
+            &mut transport.worker,
+            &mut execution,
+            &test_host_config(5),
+            RuntimeMetrics::default(),
+            peer,
+            10,
+            Ok(()),
+        )
+        .expect_err("terminal frame larger than scratch remains fatal");
+
+        assert!(matches!(err, WorkerRuntimeError::ControlFrameTooLarge));
+        assert!(matches!(
+            execution.pending_terminal,
+            Some(PendingTerminalControl::Complete { session_epoch: 10 })
+        ));
+    }
 
     #[test]
     fn deactivation_helper_preserves_primary_failure() {
@@ -1313,7 +3347,18 @@ fn handle_steps(
                     .runtime
                     .take_physical_plan()
                     .ok_or(WorkerRuntimeError::MissingPhysicalPlan)?;
-                let spill_dir = spill_runtime.execution_dir(peer, result.session_epoch)?;
+                let Some(spill_dir) = execution_spill_dir_or_fail(
+                    transport,
+                    execution,
+                    spill_runtime,
+                    config,
+                    metrics,
+                    peer,
+                    result.session_epoch,
+                )?
+                else {
+                    continue;
+                };
                 execution.worker_start_ns = Some(worker_start);
                 let spill_dir_created = spill_dir.path().is_some();
                 if spill_dir_created {
@@ -1396,6 +3441,32 @@ fn handle_steps(
         }
     }
     Ok(())
+}
+
+fn execution_spill_dir_or_fail(
+    transport: &mut TransportWorkerRuntime,
+    execution: &mut ActiveWorkerExecution,
+    spill_runtime: &mut WorkerSpillRuntime,
+    config: &crate::HostConfig,
+    metrics: RuntimeMetrics,
+    peer: BackendLeaseSlot,
+    session_epoch: u64,
+) -> Result<Option<ExecutionSpillDir>, WorkerRuntimeError> {
+    match spill_runtime.execution_dir(peer, session_epoch) {
+        Ok(spill_dir) => Ok(Some(spill_dir)),
+        Err(err) => {
+            finish_execution_task(
+                transport,
+                execution,
+                config,
+                metrics,
+                peer,
+                session_epoch,
+                Err(err),
+            )?;
+            Ok(None)
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/pg/extension/src/worker.rs
+++ b/pg/extension/src/worker.rs
@@ -282,6 +282,7 @@ fn run_scan_worker_main(job_id: usize) -> Result<(), String> {
         BackendService::run_standalone_scan_producer(StandaloneScanProducerInput {
             descriptor: job.descriptor,
             session_epoch: job.session_epoch,
+            runtime_filter_exec_id: job.runtime_filter_exec_id,
             scan_id: job.scan_id,
             producer_id: job.producer_id,
             producer_count: job.producer_count,

--- a/pg/extension/src/worker.rs
+++ b/pg/extension/src/worker.rs
@@ -1,5 +1,9 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::ffi::CStr;
+use std::io::{self, Read, Write};
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::raw::c_long;
+use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -8,8 +12,8 @@ use ::metrics::{MetricId, PageDirection, RuntimeMetrics};
 use ::worker::{
     record_datafusion_spill_leaks, record_datafusion_spill_metrics, DecodedInbound,
     ExecutionSpillDir, ResultPageEmitter, ResultPageProducerConfig, ResultPageStep,
-    ScanIngressProvider, TransportScanBatchSource, TransportWorkerRuntime, WorkerRuntimeCore,
-    WorkerRuntimeError, WorkerRuntimeStep, WorkerSpillRuntime,
+    ScanIngressProvider, TransportScanBatchSource, TransportWorkerRuntime, WorkerRuntimeConfig,
+    WorkerRuntimeCore, WorkerRuntimeError, WorkerRuntimeStep, WorkerSpillRuntime,
 };
 use backend_service::{BackendService, StandaloneScanProducerInput};
 use control_transport::WorkerTransport;
@@ -23,6 +27,8 @@ use protocol::{
     ExecutionFailureCode, WorkerExecutionToBackend, MAX_EXECUTION_FAILURE_DETAIL_LEN,
     RUNTIME_ENVELOPE_HEADER_LEN,
 };
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
 use tracing::{debug, info, trace, warn, Level};
 use transfer::PageTx;
 
@@ -34,6 +40,181 @@ use crate::shmem::{
 };
 
 const POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+type WorkerTaskSender = mpsc::Sender<WorkerTaskEvent>;
+type WorkerTaskReceiver = mpsc::Receiver<WorkerTaskEvent>;
+type WorkerTaskAck = oneshot::Sender<Result<(), WorkerRuntimeError>>;
+
+struct ActiveWorkerExecution {
+    runtime: WorkerRuntimeCore,
+    plan_rx: Option<IssuedRx>,
+    task: Option<JoinHandle<()>>,
+    worker_start_ns: Option<u64>,
+}
+
+impl ActiveWorkerExecution {
+    fn new(config: WorkerRuntimeConfig, scan_source: Arc<dyn ::worker::ScanBatchSource>) -> Self {
+        Self {
+            runtime: WorkerRuntimeCore::new(config, scan_source),
+            plan_rx: None,
+            task: None,
+            worker_start_ns: None,
+        }
+    }
+
+    fn abort_task(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+enum WorkerTaskEvent {
+    PhysicalPlanningFinished {
+        peer: BackendLeaseSlot,
+        flow: plan_flow::FlowId,
+        result: Result<Arc<dyn ExecutionPlan>, WorkerRuntimeError>,
+    },
+    ResultPage {
+        peer: BackendLeaseSlot,
+        session_epoch: u64,
+        outbound: issuance::IssuedOutboundPage,
+        ack: WorkerTaskAck,
+    },
+    ResultClose {
+        peer: BackendLeaseSlot,
+        session_epoch: u64,
+        frame: issuance::IssuedOwnedFrame,
+        ack: WorkerTaskAck,
+    },
+    ExecutionFinished {
+        peer: BackendLeaseSlot,
+        session_epoch: u64,
+        result: Result<(), WorkerRuntimeError>,
+    },
+}
+
+struct ExecutionTaskInput {
+    task_tx: WorkerTaskNotifier,
+    page_pool: PagePool,
+    issuance_pool: IssuancePool,
+    metrics: RuntimeMetrics,
+    peer: BackendLeaseSlot,
+    session_epoch: u64,
+    plan: Arc<dyn ExecutionPlan>,
+    task_ctx: Arc<datafusion_execution::TaskContext>,
+    spill_dir: ExecutionSpillDir,
+    spill_dir_created: bool,
+    estimator_initial_tail_bytes_per_row: u32,
+    #[cfg(feature = "pg_test")]
+    test_execution_gate: crate::test_gate::TestExecutionGateHandle,
+}
+
+struct WorkerSchedulerWake {
+    reader: UnixStream,
+    sender: WorkerSchedulerWakeSender,
+}
+
+impl WorkerSchedulerWake {
+    fn new() -> Result<Self, WorkerRuntimeError> {
+        let (reader, writer) = UnixStream::pair().map_err(|err| {
+            WorkerRuntimeError::ProtocolViolation(format!(
+                "failed to create worker scheduler wake socket: {err}"
+            ))
+        })?;
+        reader.set_nonblocking(true).map_err(|err| {
+            WorkerRuntimeError::ProtocolViolation(format!(
+                "failed to configure worker scheduler wake reader: {err}"
+            ))
+        })?;
+        writer.set_nonblocking(true).map_err(|err| {
+            WorkerRuntimeError::ProtocolViolation(format!(
+                "failed to configure worker scheduler wake writer: {err}"
+            ))
+        })?;
+        Ok(Self {
+            reader,
+            sender: WorkerSchedulerWakeSender {
+                writer: Arc::new(writer),
+            },
+        })
+    }
+
+    fn sender(&self) -> WorkerSchedulerWakeSender {
+        self.sender.clone()
+    }
+
+    fn read_fd(&self) -> RawFd {
+        self.reader.as_raw_fd()
+    }
+
+    fn drain(&mut self) -> usize {
+        let mut buf = [0_u8; 64];
+        let mut drained = 0;
+        loop {
+            match self.reader.read(&mut buf) {
+                Ok(0) => return drained,
+                Ok(bytes) => drained += bytes,
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => return drained,
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+                Err(err) => {
+                    warn!(
+                        component = "worker",
+                        error = %err,
+                        "failed to drain worker scheduler wake socket"
+                    );
+                    return drained;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct WorkerSchedulerWakeSender {
+    writer: Arc<UnixStream>,
+}
+
+impl WorkerSchedulerWakeSender {
+    fn wake(&self) -> io::Result<()> {
+        let mut writer = self.writer.as_ref();
+        loop {
+            match writer.write(&[1]) {
+                Ok(_) => return Ok(()),
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+                Err(err) => return Err(err),
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct WorkerTaskNotifier {
+    tx: WorkerTaskSender,
+    wake: WorkerSchedulerWakeSender,
+}
+
+impl WorkerTaskNotifier {
+    fn new(tx: WorkerTaskSender, wake: WorkerSchedulerWakeSender) -> Self {
+        Self { tx, wake }
+    }
+
+    async fn send(
+        &self,
+        event: WorkerTaskEvent,
+    ) -> Result<(), mpsc::error::SendError<WorkerTaskEvent>> {
+        self.tx.send(event).await?;
+        if let Err(err) = self.wake.wake() {
+            warn!(
+                component = "worker",
+                error = %err,
+                "failed to wake worker scheduler after task event"
+            );
+        }
+        Ok(())
+    }
+}
 
 pub(crate) fn register_background_worker() {
     BackgroundWorkerBuilder::new("pg_fusion")
@@ -197,17 +378,23 @@ fn run_worker_main() -> Result<(), WorkerRuntimeError> {
                 );
             }
 
-            let scan_source = Arc::new(TransportScanBatchSource::new_with_metrics(
-                scan_region,
-                config.scan_backend_to_worker_capacity,
-                Arc::new(SharedScanIngress {
-                    page_pool,
-                    issuance_pool,
-                }),
-                metrics,
-            )?);
-            let mut runtime = WorkerRuntimeCore::new(worker_config, scan_source);
-            let mut plan_rx: Option<IssuedRx> = None;
+            let scan_source: Arc<dyn ::worker::ScanBatchSource> =
+                Arc::new(TransportScanBatchSource::new_with_metrics(
+                    scan_region,
+                    config.scan_backend_to_worker_capacity,
+                    Arc::new(SharedScanIngress {
+                        page_pool,
+                        issuance_pool,
+                    }),
+                    metrics,
+                )?);
+            let mut scheduler_wake = WorkerSchedulerWake::new()?;
+            let (task_event_tx, mut task_rx) =
+                mpsc::channel(config.max_fusion_tasks.saturating_mul(4).max(1));
+            let task_tx = WorkerTaskNotifier::new(task_event_tx, scheduler_wake.sender());
+            let mut executions: HashMap<BackendLeaseSlot, ActiveWorkerExecution> = HashMap::new();
+            #[cfg(feature = "pg_test")]
+            let test_execution_gate = crate::test_gate::attach();
             let df_runtime_plan = resolve_datafusion_runtime_plan(config.worker_threads);
             let df_runtime = build_datafusion_runtime(df_runtime_plan)?;
             info!(
@@ -219,100 +406,106 @@ fn run_worker_main() -> Result<(), WorkerRuntimeError> {
             );
             debug!(component = "worker", "worker entering main poll loop");
 
-            while BackgroundWorker::wait_latch(Some(POLL_INTERVAL)) {
-                if let Some(peer) = runtime.active_peer() {
+            while wait_worker_scheduler(&mut scheduler_wake, POLL_INTERVAL) {
+                drain_task_events(
+                    &mut executions,
+                    &mut transport,
+                    &df_runtime,
+                    &mut spill_runtime,
+                    &config,
+                    page_pool,
+                    issuance_pool,
+                    metrics,
+                    &mut task_rx,
+                    &task_tx,
+                    #[cfg(feature = "pg_test")]
+                    test_execution_gate,
+                )?;
+
+                let active_peers = executions.keys().copied().collect::<Vec<_>>();
+                for peer in active_peers {
                     trace!(
                         component = "worker",
                         peer = ?peer,
-                        state = ?runtime.state(),
                         "worker probing active backend peer"
                     );
-                    let steps = recv_backend_peer_steps(
+                    poll_execution_peer(
+                        &mut executions,
                         &mut transport,
-                        &mut runtime,
-                        peer,
-                        page_pool,
-                        issuance_pool,
-                        &mut plan_rx,
-                    )?;
-                    handle_steps(
-                        &mut transport,
-                        &mut runtime,
                         &df_runtime,
                         &mut spill_runtime,
                         &config,
+                        &worker_config,
+                        &scan_source,
+                        &task_tx,
+                        #[cfg(feature = "pg_test")]
+                        test_execution_gate,
+                        peer,
                         page_pool,
                         issuance_pool,
-                        &mut plan_rx,
                         metrics,
-                        steps,
                     )?;
                 }
 
                 let mut ready_cursor = 0;
                 while let Some(peer) = transport.next_ready_backend_lease(&mut ready_cursor) {
-                    if let Some(active_peer) = runtime.active_peer() {
-                        if active_peer != peer {
-                            trace!(
-                                component = "worker",
-                                peer = ?active_peer,
-                                incoming_peer = ?peer,
-                                state = ?runtime.state(),
-                                "worker probing active backend peer before non-active peer"
-                            );
-                            let steps = recv_backend_peer_steps(
-                                &mut transport,
-                                &mut runtime,
-                                active_peer,
-                                page_pool,
-                                issuance_pool,
-                                &mut plan_rx,
-                            )?;
-                            handle_steps(
-                                &mut transport,
-                                &mut runtime,
-                                &df_runtime,
-                                &mut spill_runtime,
-                                &config,
-                                page_pool,
-                                issuance_pool,
-                                &mut plan_rx,
-                                metrics,
-                                steps,
-                            )?;
-                        }
+                    if executions.contains_key(&peer) {
+                        continue;
+                    }
+                    if executions.len() >= config.max_fusion_tasks {
+                        trace!(
+                            component = "worker",
+                            peer = ?peer,
+                            active_executions = executions.len(),
+                            max_fusion_tasks = config.max_fusion_tasks,
+                            "worker deferring new backend peer because fusion task limit is reached"
+                        );
+                        continue;
                     }
                     if tracing::enabled!(Level::TRACE) {
                         trace!(
                             component = "worker",
                             peer = ?peer,
-                            state = ?runtime.state(),
                             "worker polling ready backend peer"
                         );
                     }
-                    let steps = recv_backend_peer_steps(
+                    poll_execution_peer(
+                        &mut executions,
                         &mut transport,
-                        &mut runtime,
-                        peer,
-                        page_pool,
-                        issuance_pool,
-                        &mut plan_rx,
-                    )?;
-                    handle_steps(
-                        &mut transport,
-                        &mut runtime,
                         &df_runtime,
                         &mut spill_runtime,
                         &config,
+                        &worker_config,
+                        &scan_source,
+                        &task_tx,
+                        #[cfg(feature = "pg_test")]
+                        test_execution_gate,
+                        peer,
                         page_pool,
                         issuance_pool,
-                        &mut plan_rx,
                         metrics,
-                        steps,
                     )?;
                 }
+
+                drain_task_events(
+                    &mut executions,
+                    &mut transport,
+                    &df_runtime,
+                    &mut spill_runtime,
+                    &config,
+                    page_pool,
+                    issuance_pool,
+                    metrics,
+                    &mut task_rx,
+                    &task_tx,
+                    #[cfg(feature = "pg_test")]
+                    test_execution_gate,
+                )?;
             }
 
+            for execution in executions.values_mut() {
+                execution.abort_task();
+            }
             Ok(())
         })();
 
@@ -330,6 +523,224 @@ fn run_worker_main() -> Result<(), WorkerRuntimeError> {
     )?;
     info!(component = "worker", "worker stopped cleanly");
     Ok(())
+}
+
+fn wait_worker_scheduler(wake: &mut WorkerSchedulerWake, timeout: Duration) -> bool {
+    let timeout_ms = timeout.as_millis().try_into().unwrap_or(c_long::MAX);
+    let wake_events = (pgrx::pg_sys::WL_LATCH_SET
+        | pgrx::pg_sys::WL_SOCKET_READABLE
+        | pgrx::pg_sys::WL_TIMEOUT
+        | pgrx::pg_sys::WL_POSTMASTER_DEATH) as i32;
+
+    let wakeup_flags = unsafe {
+        let flags = pgrx::pg_sys::WaitLatchOrSocket(
+            pgrx::pg_sys::MyLatch,
+            wake_events,
+            wake.read_fd() as pgrx::pg_sys::pgsocket,
+            timeout_ms,
+            pgrx::pg_sys::PG_WAIT_EXTENSION,
+        );
+        pgrx::pg_sys::ResetLatch(pgrx::pg_sys::MyLatch);
+        pgrx::pg_sys::check_for_interrupts!();
+        flags
+    };
+
+    if wakeup_flags & pgrx::pg_sys::WL_SOCKET_READABLE as i32 != 0 {
+        wake.drain();
+    }
+
+    let postmaster_died = wakeup_flags & pgrx::pg_sys::WL_POSTMASTER_DEATH as i32 != 0;
+    !BackgroundWorker::sigterm_received() && !postmaster_died
+}
+
+#[allow(clippy::too_many_arguments)]
+fn poll_execution_peer(
+    executions: &mut HashMap<BackendLeaseSlot, ActiveWorkerExecution>,
+    transport: &mut TransportWorkerRuntime,
+    df_runtime: &tokio::runtime::Runtime,
+    spill_runtime: &mut WorkerSpillRuntime,
+    config: &crate::HostConfig,
+    worker_config: &WorkerRuntimeConfig,
+    scan_source: &Arc<dyn ::worker::ScanBatchSource>,
+    task_tx: &WorkerTaskNotifier,
+    #[cfg(feature = "pg_test")] test_execution_gate: crate::test_gate::TestExecutionGateHandle,
+    peer: BackendLeaseSlot,
+    page_pool: PagePool,
+    issuance_pool: IssuancePool,
+    metrics: RuntimeMetrics,
+) -> Result<(), WorkerRuntimeError> {
+    let mut execution = executions.remove(&peer).unwrap_or_else(|| {
+        ActiveWorkerExecution::new(worker_config.clone(), Arc::clone(scan_source))
+    });
+    let steps = recv_backend_peer_steps(
+        transport,
+        &mut execution.runtime,
+        peer,
+        page_pool,
+        issuance_pool,
+        &mut execution.plan_rx,
+    )?;
+    handle_steps(
+        transport,
+        &mut execution,
+        df_runtime,
+        spill_runtime,
+        config,
+        page_pool,
+        issuance_pool,
+        metrics,
+        task_tx,
+        #[cfg(feature = "pg_test")]
+        test_execution_gate,
+        steps,
+    )?;
+    if execution.runtime.active_peer().is_some() {
+        executions.insert(peer, execution);
+    } else {
+        execution.abort_task();
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn drain_task_events(
+    executions: &mut HashMap<BackendLeaseSlot, ActiveWorkerExecution>,
+    transport: &mut TransportWorkerRuntime,
+    df_runtime: &tokio::runtime::Runtime,
+    spill_runtime: &mut WorkerSpillRuntime,
+    config: &crate::HostConfig,
+    page_pool: PagePool,
+    issuance_pool: IssuancePool,
+    metrics: RuntimeMetrics,
+    task_rx: &mut WorkerTaskReceiver,
+    task_tx: &WorkerTaskNotifier,
+    #[cfg(feature = "pg_test")] test_execution_gate: crate::test_gate::TestExecutionGateHandle,
+) -> Result<(), WorkerRuntimeError> {
+    while let Ok(event) = task_rx.try_recv() {
+        handle_task_event(
+            executions,
+            transport,
+            df_runtime,
+            spill_runtime,
+            config,
+            page_pool,
+            issuance_pool,
+            metrics,
+            task_tx,
+            #[cfg(feature = "pg_test")]
+            test_execution_gate,
+            event,
+        )?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_task_event(
+    executions: &mut HashMap<BackendLeaseSlot, ActiveWorkerExecution>,
+    transport: &mut TransportWorkerRuntime,
+    df_runtime: &tokio::runtime::Runtime,
+    spill_runtime: &mut WorkerSpillRuntime,
+    config: &crate::HostConfig,
+    page_pool: PagePool,
+    issuance_pool: IssuancePool,
+    metrics: RuntimeMetrics,
+    task_tx: &WorkerTaskNotifier,
+    #[cfg(feature = "pg_test")] test_execution_gate: crate::test_gate::TestExecutionGateHandle,
+    event: WorkerTaskEvent,
+) -> Result<(), WorkerRuntimeError> {
+    match event {
+        WorkerTaskEvent::PhysicalPlanningFinished { peer, flow, result } => {
+            let Some(mut execution) = executions.remove(&peer) else {
+                return Ok(());
+            };
+            execution.task = None;
+            let step = execution
+                .runtime
+                .finish_physical_planning(peer, flow, result)?;
+            handle_steps(
+                transport,
+                &mut execution,
+                df_runtime,
+                spill_runtime,
+                config,
+                page_pool,
+                issuance_pool,
+                metrics,
+                task_tx,
+                #[cfg(feature = "pg_test")]
+                test_execution_gate,
+                VecDeque::from([step]),
+            )?;
+            if execution.runtime.active_peer().is_some() {
+                executions.insert(peer, execution);
+            } else {
+                execution.abort_task();
+            }
+        }
+        WorkerTaskEvent::ResultPage {
+            peer,
+            session_epoch,
+            outbound,
+            ack,
+        } => {
+            let result = if active_execution_session_matches(executions, peer, session_epoch) {
+                send_result_page_from_task(transport, metrics, peer, session_epoch, outbound)
+            } else {
+                Err(stale_execution_task_error(peer, session_epoch))
+            };
+            let _ = ack.send(result);
+        }
+        WorkerTaskEvent::ResultClose {
+            peer,
+            session_epoch,
+            frame,
+            ack,
+        } => {
+            let result = if active_execution_session_matches(executions, peer, session_epoch) {
+                send_result_close_from_task(transport, peer, session_epoch, frame)
+            } else {
+                Err(stale_execution_task_error(peer, session_epoch))
+            };
+            let _ = ack.send(result);
+        }
+        WorkerTaskEvent::ExecutionFinished {
+            peer,
+            session_epoch,
+            result,
+        } => {
+            let Some(mut execution) = executions.remove(&peer) else {
+                return Ok(());
+            };
+            execution.task = None;
+            finish_execution_task(
+                transport,
+                &mut execution,
+                config,
+                metrics,
+                peer,
+                session_epoch,
+                result,
+            )?;
+            if execution.runtime.active_peer().is_some() {
+                executions.insert(peer, execution);
+            } else {
+                execution.abort_task();
+            }
+        }
+    }
+    Ok(())
+}
+
+fn active_execution_session_matches(
+    executions: &HashMap<BackendLeaseSlot, ActiveWorkerExecution>,
+    peer: BackendLeaseSlot,
+    session_epoch: u64,
+) -> bool {
+    executions
+        .get(&peer)
+        .and_then(|execution| execution.runtime.session_epoch())
+        == Some(session_epoch)
 }
 
 fn recv_backend_peer_steps(
@@ -381,6 +792,175 @@ fn recv_backend_peer_steps(
         }
         Err(err) => Err(err),
     }
+}
+
+fn send_result_page_from_task(
+    transport: &mut TransportWorkerRuntime,
+    metrics: RuntimeMetrics,
+    peer: BackendLeaseSlot,
+    session_epoch: u64,
+    outbound: issuance::IssuedOutboundPage,
+) -> Result<(), WorkerRuntimeError> {
+    trace!(
+        component = "worker",
+        session_epoch,
+        peer = ?peer,
+        "worker produced one result page"
+    );
+    let descriptor = outbound.descriptor();
+    let payload_len = outbound.payload_len();
+    let frame = encode_issued_frame(outbound.frame()).map_err(|err| {
+        WorkerRuntimeError::ProtocolViolation(format!("failed to encode result page frame: {err}"))
+    })?;
+    transport.send_peer_bytes(peer, &frame)?;
+    metrics.stamp_page(PageDirection::WorkerToBackend, descriptor, payload_len);
+    metrics.increment(MetricId::WorkerResultPagesTotal);
+    metrics.add(MetricId::WorkerResultBytesSentTotal, payload_len as u64);
+    outbound.mark_sent();
+    Ok(())
+}
+
+fn send_result_close_from_task(
+    transport: &mut TransportWorkerRuntime,
+    peer: BackendLeaseSlot,
+    session_epoch: u64,
+    frame: issuance::IssuedOwnedFrame,
+) -> Result<(), WorkerRuntimeError> {
+    debug!(
+        component = "worker",
+        session_epoch,
+        peer = ?peer,
+        "worker produced terminal result close frame"
+    );
+    let frame = encode_issued_frame(frame).map_err(|err| {
+        WorkerRuntimeError::ProtocolViolation(format!("failed to encode result close frame: {err}"))
+    })?;
+    transport.send_peer_bytes(peer, &frame)?;
+    Ok(())
+}
+
+fn finish_execution_task(
+    transport: &mut TransportWorkerRuntime,
+    execution: &mut ActiveWorkerExecution,
+    config: &crate::HostConfig,
+    metrics: RuntimeMetrics,
+    peer: BackendLeaseSlot,
+    session_epoch: u64,
+    result: Result<(), WorkerRuntimeError>,
+) -> Result<(), WorkerRuntimeError> {
+    let worker_start = execution.worker_start_ns.take();
+    match result {
+        Ok(()) => {
+            info!(
+                component = "worker",
+                session_epoch,
+                peer = ?peer,
+                "worker finished execution successfully and is sending CompleteExecution"
+            );
+            if let Err(err) = transport.send_peer_message(
+                peer,
+                WorkerExecutionToBackend::CompleteExecution { session_epoch },
+            ) {
+                if is_detached_backend_peer_error(&err) {
+                    warn!(
+                        component = "worker",
+                        session_epoch,
+                        peer = ?peer,
+                        error = %err,
+                        "worker could not send CompleteExecution because backend peer detached"
+                    );
+                } else {
+                    return Err(err);
+                }
+            }
+            if let Some(worker_start) = worker_start {
+                metrics.add_elapsed(MetricId::WorkerTotalNs, worker_start);
+            }
+            let step = execution.runtime.mark_execution_complete()?;
+            handle_terminal_step(execution, step)?;
+        }
+        Err(err) => {
+            let detail =
+                worker_execution_failure_detail(&err, config.control_backend_to_worker_capacity);
+            warn!(
+                component = "worker",
+                session_epoch,
+                peer = ?peer,
+                error = %err,
+                "worker execution failed locally; sending FailExecution"
+            );
+            if let Err(send_err) = transport.send_peer_message(
+                peer,
+                WorkerExecutionToBackend::FailExecution {
+                    session_epoch,
+                    code: ExecutionFailureCode::Internal,
+                    detail,
+                },
+            ) {
+                if is_detached_backend_peer_error(&send_err) {
+                    warn!(
+                        component = "worker",
+                        session_epoch,
+                        peer = ?peer,
+                        error = %send_err,
+                        "worker could not send FailExecution because backend peer detached"
+                    );
+                } else {
+                    return Err(send_err);
+                }
+            }
+            if let Some(worker_start) = worker_start {
+                metrics.add_elapsed(MetricId::WorkerTotalNs, worker_start);
+            }
+            let step = execution
+                .runtime
+                .fail_execution_locally(ExecutionFailureCode::Internal, None)?;
+            handle_terminal_step(execution, step)?;
+        }
+    }
+    Ok(())
+}
+
+fn handle_terminal_step(
+    execution: &mut ActiveWorkerExecution,
+    step: WorkerRuntimeStep,
+) -> Result<(), WorkerRuntimeError> {
+    match step {
+        WorkerRuntimeStep::ExecutionCancelled { session_epoch } => {
+            info!(
+                component = "worker",
+                session_epoch, "worker observed execution cancel"
+            );
+            execution.plan_rx.take();
+        }
+        WorkerRuntimeStep::ExecutionFailed {
+            session_epoch,
+            code,
+            detail,
+        } => {
+            warn!(
+                component = "worker",
+                session_epoch,
+                code = ?code,
+                detail = ?detail,
+                "worker observed execution failure transition"
+            );
+            execution.plan_rx.take();
+        }
+        WorkerRuntimeStep::ExecutionCompleted { session_epoch } => {
+            info!(
+                component = "worker",
+                session_epoch, "worker observed execution complete transition"
+            );
+            execution.plan_rx.take();
+        }
+        _ => return Ok(()),
+    }
+
+    if execution.runtime.state() == ::worker::fsm::WorkerExecutionState::Terminal {
+        execution.runtime.cleanup()?;
+    }
+    Ok(())
 }
 
 fn finish_with_deactivation(
@@ -568,13 +1148,13 @@ mod tests {
     }
 
     #[test]
-    fn datafusion_runtime_plan_uses_explicit_current_thread() {
+    fn datafusion_runtime_plan_uses_explicit_single_worker_thread() {
         let plan = resolve_datafusion_runtime_plan_with(Some(1), || 8);
 
         assert_eq!(plan.requested_worker_threads, Some(1));
         assert_eq!(plan.worker_threads, 1);
-        assert_eq!(plan.mode, DataFusionRuntimeMode::CurrentThread);
-        assert_eq!(plan.mode.as_str(), "current-thread");
+        assert_eq!(plan.mode, DataFusionRuntimeMode::MultiThread);
+        assert_eq!(plan.mode.as_str(), "multi-thread");
     }
 
     #[test]
@@ -601,7 +1181,56 @@ mod tests {
         let plan = resolve_datafusion_runtime_plan_with(None, || 0);
 
         assert_eq!(plan.worker_threads, 1);
-        assert_eq!(plan.mode, DataFusionRuntimeMode::CurrentThread);
+        assert_eq!(plan.mode, DataFusionRuntimeMode::MultiThread);
+    }
+
+    #[test]
+    fn scheduler_wake_drains_nonblocking_notifications() {
+        let mut wake = WorkerSchedulerWake::new().expect("create scheduler wake");
+        let sender = wake.sender();
+
+        sender.wake().expect("wake scheduler");
+        sender.wake().expect("coalesce second scheduler wake");
+        assert!(wake.drain() >= 1);
+        assert_eq!(wake.drain(), 0);
+        sender.wake().expect("wake after drain");
+        assert_eq!(wake.drain(), 1);
+    }
+
+    #[test]
+    fn task_notifier_wakes_after_event_send() {
+        let mut wake = WorkerSchedulerWake::new().expect("create scheduler wake");
+        let (tx, mut rx) = mpsc::channel(1);
+        let notifier = WorkerTaskNotifier::new(tx, wake.sender());
+        let peer = BackendLeaseSlot::new(0, control_transport::BackendLeaseId::new(1, 1));
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("create test runtime");
+
+        runtime.block_on(async {
+            notifier
+                .send(WorkerTaskEvent::ExecutionFinished {
+                    peer,
+                    session_epoch: 42,
+                    result: Ok(()),
+                })
+                .await
+                .expect("send task event");
+        });
+
+        assert_eq!(wake.drain(), 1);
+        match rx.try_recv().expect("receive task event") {
+            WorkerTaskEvent::ExecutionFinished {
+                peer: received_peer,
+                session_epoch,
+                result,
+            } => {
+                assert_eq!(received_peer, peer);
+                assert_eq!(session_epoch, 42);
+                assert!(result.is_ok());
+            }
+            _ => panic!("unexpected task event"),
+        }
     }
 
     fn protocol_error(message: &str) -> WorkerRuntimeError {
@@ -623,14 +1252,15 @@ mod tests {
 #[allow(clippy::too_many_arguments)]
 fn handle_steps(
     transport: &mut TransportWorkerRuntime,
-    runtime: &mut WorkerRuntimeCore,
+    execution: &mut ActiveWorkerExecution,
     df_runtime: &tokio::runtime::Runtime,
     spill_runtime: &mut WorkerSpillRuntime,
     config: &crate::HostConfig,
     page_pool: PagePool,
     issuance_pool: IssuancePool,
-    plan_rx: &mut Option<IssuedRx>,
     metrics: RuntimeMetrics,
+    task_tx: &WorkerTaskNotifier,
+    #[cfg(feature = "pg_test")] test_execution_gate: crate::test_gate::TestExecutionGateHandle,
     mut steps: VecDeque<WorkerRuntimeStep>,
 ) -> Result<(), WorkerRuntimeError> {
     while let Some(step) = steps.pop_front() {
@@ -657,14 +1287,20 @@ fn handle_steps(
                     flow = ?flow,
                     "worker starting physical planning"
                 );
-                let plan_start = metrics.now_ns();
-                let result = df_runtime.block_on(pending.plan());
-                metrics.add_elapsed(MetricId::WorkerPhysicalPlanNs, plan_start);
-                metrics.increment(MetricId::WorkerPhysicalPlanTotal);
-                steps.push_back(runtime.finish_physical_planning(peer, flow, result)?);
+                let task_tx = task_tx.clone();
+                execution.abort_task();
+                execution.task = Some(df_runtime.spawn(async move {
+                    let plan_start = metrics.now_ns();
+                    let result = pending.plan().await;
+                    metrics.add_elapsed(MetricId::WorkerPhysicalPlanNs, plan_start);
+                    metrics.increment(MetricId::WorkerPhysicalPlanTotal);
+                    let _ = task_tx
+                        .send(WorkerTaskEvent::PhysicalPlanningFinished { peer, flow, result })
+                        .await;
+                }));
             }
             WorkerRuntimeStep::PhysicalPlanReady(result) => {
-                let peer = runtime.active_peer().expect("peer");
+                let peer = execution.runtime.active_peer().expect("peer");
                 let worker_start = metrics.now_ns();
                 info!(
                     component = "worker",
@@ -672,139 +1308,89 @@ fn handle_steps(
                     peer = ?peer,
                     "worker received physical plan and is starting execution"
                 );
-                let execution_result: Result<(), WorkerRuntimeError> = runtime
+                let plan = execution
+                    .runtime
                     .take_physical_plan()
-                    .ok_or(WorkerRuntimeError::MissingPhysicalPlan)
-                    .and_then(|plan| {
-                        df_runtime.block_on(execute_physical_plan(
-                            transport,
-                            spill_runtime,
-                            config,
-                            page_pool,
-                            issuance_pool,
+                    .ok_or(WorkerRuntimeError::MissingPhysicalPlan)?;
+                let spill_dir = spill_runtime.execution_dir(peer, result.session_epoch)?;
+                execution.worker_start_ns = Some(worker_start);
+                let spill_dir_created = spill_dir.path().is_some();
+                if spill_dir_created {
+                    metrics.increment(MetricId::WorkerSpillDirsCreatedTotal);
+                }
+                let task_ctx = match spill_runtime.task_context(&spill_dir) {
+                    Ok(task_ctx) => task_ctx,
+                    Err(err) => {
+                        let cleanup_result = cleanup_execution_spill_dir(
+                            spill_dir,
+                            spill_dir_created,
                             metrics,
                             peer,
                             result.session_epoch,
-                            plan,
-                        ))
-                    });
+                        );
+                        if let Err(cleanup_err) = cleanup_result {
+                            warn!(
+                                component = "worker",
+                                session_epoch = result.session_epoch,
+                                peer = ?peer,
+                                error = %cleanup_err,
+                                "worker failed to clean execution spill directory after task context failure"
+                            );
+                        }
+                        finish_execution_task(
+                            transport,
+                            execution,
+                            config,
+                            metrics,
+                            peer,
+                            result.session_epoch,
+                            Err(err),
+                        )?;
+                        continue;
+                    }
+                };
 
-                match execution_result {
-                    Ok(()) => {
-                        info!(
-                            component = "worker",
-                            session_epoch = result.session_epoch,
-                            peer = ?peer,
-                            "worker finished execution successfully and is sending CompleteExecution"
-                        );
-                        if let Err(err) = transport.send_peer_message(
+                let task_input = ExecutionTaskInput {
+                    task_tx: task_tx.clone(),
+                    page_pool,
+                    issuance_pool,
+                    metrics,
+                    peer,
+                    session_epoch: result.session_epoch,
+                    plan,
+                    task_ctx,
+                    spill_dir,
+                    spill_dir_created,
+                    estimator_initial_tail_bytes_per_row: config
+                        .estimator_initial_tail_bytes_per_row,
+                    #[cfg(feature = "pg_test")]
+                    test_execution_gate,
+                };
+                execution.abort_task();
+                execution.task = Some(df_runtime.spawn(async move {
+                    let peer = task_input.peer;
+                    let session_epoch = task_input.session_epoch;
+                    let task_tx = task_input.task_tx.clone();
+                    let result = execute_physical_plan_task(task_input).await;
+                    let _ = task_tx
+                        .send(WorkerTaskEvent::ExecutionFinished {
                             peer,
-                            WorkerExecutionToBackend::CompleteExecution {
-                                session_epoch: result.session_epoch,
-                            },
-                        ) {
-                            if is_detached_backend_peer_error(&err) {
-                                warn!(
-                                    component = "worker",
-                                    session_epoch = result.session_epoch,
-                                    peer = ?peer,
-                                    error = %err,
-                                    "worker could not send CompleteExecution because backend peer detached"
-                                );
-                            } else {
-                                return Err(err);
-                            }
-                        }
-                        metrics.add_elapsed(MetricId::WorkerTotalNs, worker_start);
-                        steps.push_back(runtime.mark_execution_complete()?);
-                    }
-                    Err(err) => {
-                        let detail = worker_execution_failure_detail(
-                            &err,
-                            config.control_backend_to_worker_capacity,
-                        );
-                        warn!(
-                            component = "worker",
-                            session_epoch = result.session_epoch,
-                            peer = ?peer,
-                            error = %err,
-                            "worker execution failed locally; sending FailExecution"
-                        );
-                        if let Err(send_err) = transport.send_peer_message(
-                            peer,
-                            WorkerExecutionToBackend::FailExecution {
-                                session_epoch: result.session_epoch,
-                                code: ExecutionFailureCode::Internal,
-                                detail,
-                            },
-                        ) {
-                            if is_detached_backend_peer_error(&send_err) {
-                                warn!(
-                                    component = "worker",
-                                    session_epoch = result.session_epoch,
-                                    peer = ?peer,
-                                    error = %send_err,
-                                    "worker could not send FailExecution because backend peer detached"
-                                );
-                            } else {
-                                return Err(send_err);
-                            }
-                        }
-                        metrics.add_elapsed(MetricId::WorkerTotalNs, worker_start);
-                        steps.push_back(
-                            runtime.fail_execution_locally(ExecutionFailureCode::Internal, None)?,
-                        );
-                    }
-                }
+                            session_epoch,
+                            result,
+                        })
+                        .await;
+                }));
             }
-            WorkerRuntimeStep::ExecutionCancelled { session_epoch } => {
-                info!(
-                    component = "worker",
-                    session_epoch, "worker observed execution cancel"
-                );
-                plan_rx.take();
-                if runtime.state() == ::worker::fsm::WorkerExecutionState::Terminal {
-                    runtime.cleanup()?;
-                    info!(
-                        component = "worker",
-                        session_epoch, "worker cleaned up terminal execution after cancel"
-                    );
-                }
+            step @ WorkerRuntimeStep::ExecutionCancelled { .. } => {
+                execution.abort_task();
+                handle_terminal_step(execution, step)?;
             }
-            WorkerRuntimeStep::ExecutionFailed {
-                session_epoch,
-                code,
-                detail,
-            } => {
-                warn!(
-                    component = "worker",
-                    session_epoch,
-                    code = ?code,
-                    detail = ?detail,
-                    "worker observed execution failure transition"
-                );
-                plan_rx.take();
-                if runtime.state() == ::worker::fsm::WorkerExecutionState::Terminal {
-                    runtime.cleanup()?;
-                    info!(
-                        component = "worker",
-                        session_epoch, "worker cleaned up terminal execution after failure"
-                    );
-                }
+            step @ WorkerRuntimeStep::ExecutionFailed { .. } => {
+                execution.abort_task();
+                handle_terminal_step(execution, step)?;
             }
-            WorkerRuntimeStep::ExecutionCompleted { session_epoch } => {
-                info!(
-                    component = "worker",
-                    session_epoch, "worker observed execution complete transition"
-                );
-                plan_rx.take();
-                if runtime.state() == ::worker::fsm::WorkerExecutionState::Terminal {
-                    runtime.cleanup()?;
-                    info!(
-                        component = "worker",
-                        session_epoch, "worker cleaned up terminal execution after completion"
-                    );
-                }
+            step @ WorkerRuntimeStep::ExecutionCompleted { .. } => {
+                handle_terminal_step(execution, step)?;
             }
         }
     }
@@ -820,14 +1406,12 @@ struct DataFusionRuntimePlan {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DataFusionRuntimeMode {
-    CurrentThread,
     MultiThread,
 }
 
 impl DataFusionRuntimeMode {
     fn as_str(self) -> &'static str {
         match self {
-            Self::CurrentThread => "current-thread",
             Self::MultiThread => "multi-thread",
         }
     }
@@ -842,16 +1426,11 @@ fn resolve_datafusion_runtime_plan_with(
     default_worker_threads: impl FnOnce() -> usize,
 ) -> DataFusionRuntimePlan {
     let effective_worker_threads = worker_threads.unwrap_or_else(default_worker_threads).max(1);
-    let mode = if effective_worker_threads == 1 {
-        DataFusionRuntimeMode::CurrentThread
-    } else {
-        DataFusionRuntimeMode::MultiThread
-    };
 
     DataFusionRuntimePlan {
         requested_worker_threads: worker_threads,
         worker_threads: effective_worker_threads,
-        mode,
+        mode: DataFusionRuntimeMode::MultiThread,
     }
 }
 
@@ -864,15 +1443,10 @@ fn default_datafusion_worker_threads() -> usize {
 fn build_datafusion_runtime(
     plan: DataFusionRuntimePlan,
 ) -> Result<tokio::runtime::Runtime, WorkerRuntimeError> {
-    let result = match plan.mode {
-        DataFusionRuntimeMode::CurrentThread => tokio::runtime::Builder::new_current_thread()
-            .thread_name("pg_fusion-df")
-            .build(),
-        DataFusionRuntimeMode::MultiThread => tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(plan.worker_threads)
-            .thread_name("pg_fusion-df")
-            .build(),
-    };
+    let result = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(plan.worker_threads)
+        .thread_name("pg_fusion-df")
+        .build();
 
     result.map_err(|err| {
         WorkerRuntimeError::ProtocolViolation(format!(
@@ -882,44 +1456,25 @@ fn build_datafusion_runtime(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn execute_physical_plan(
-    transport: &mut TransportWorkerRuntime,
-    spill_runtime: &mut WorkerSpillRuntime,
-    config: &crate::HostConfig,
-    page_pool: PagePool,
-    issuance_pool: IssuancePool,
-    metrics: RuntimeMetrics,
-    peer: BackendLeaseSlot,
-    session_epoch: u64,
-    plan: Arc<dyn ExecutionPlan>,
-) -> Result<(), WorkerRuntimeError> {
-    let spill_dir = spill_runtime.execution_dir(peer, session_epoch)?;
-    let spill_dir_created = spill_dir.path().is_some();
-    if spill_dir_created {
-        metrics.increment(MetricId::WorkerSpillDirsCreatedTotal);
-    }
-    let task_ctx = match spill_runtime.task_context(&spill_dir) {
-        Ok(task_ctx) => task_ctx,
-        Err(err) => {
-            let cleanup_result = cleanup_execution_spill_dir(
-                spill_dir,
-                spill_dir_created,
-                metrics,
-                peer,
-                session_epoch,
-            );
-            if let Err(cleanup_err) = cleanup_result {
-                warn!(
-                    component = "worker",
-                    session_epoch,
-                    peer = ?peer,
-                    error = %cleanup_err,
-                    "worker failed to clean execution spill directory after task context failure"
-                );
-            }
-            return Err(err);
-        }
-    };
+async fn execute_physical_plan_task(input: ExecutionTaskInput) -> Result<(), WorkerRuntimeError> {
+    let ExecutionTaskInput {
+        task_tx,
+        page_pool,
+        issuance_pool,
+        metrics,
+        peer,
+        session_epoch,
+        plan,
+        task_ctx,
+        spill_dir,
+        spill_dir_created,
+        estimator_initial_tail_bytes_per_row,
+        #[cfg(feature = "pg_test")]
+        test_execution_gate,
+    } = input;
+    #[cfg(feature = "pg_test")]
+    test_execution_gate.wait_at_execution_start().await;
+
     let execution_result: Result<(), WorkerRuntimeError> = async {
         let stream = execute_stream(Arc::clone(&plan), Arc::clone(&task_ctx))?;
         let page_tx = PageTx::new(page_pool);
@@ -932,7 +1487,7 @@ async fn execute_physical_plan(
             payload_capacity,
             ResultPageProducerConfig {
                 estimator: row_estimator::EstimatorConfig {
-                    initial_tail_bytes_per_row: config.estimator_initial_tail_bytes_per_row,
+                    initial_tail_bytes_per_row: estimator_initial_tail_bytes_per_row,
                 },
                 metrics,
                 ..ResultPageProducerConfig::default()
@@ -942,38 +1497,30 @@ async fn execute_physical_plan(
         loop {
             match producer.next_step_async().await? {
                 Some(ResultPageStep::OutboundPage(outbound)) => {
-                    trace!(
-                        component = "worker",
-                        session_epoch,
-                        peer = ?peer,
-                        "worker produced one result page"
-                    );
-                    let descriptor = outbound.descriptor();
-                    let payload_len = outbound.payload_len();
-                    let frame = encode_issued_frame(outbound.frame()).map_err(|err| {
-                        WorkerRuntimeError::ProtocolViolation(format!(
-                            "failed to encode result page frame: {err}"
-                        ))
-                    })?;
-                    transport.send_peer_bytes(peer, &frame)?;
-                    metrics.stamp_page(PageDirection::WorkerToBackend, descriptor, payload_len);
-                    metrics.increment(MetricId::WorkerResultPagesTotal);
-                    metrics.add(MetricId::WorkerResultBytesSentTotal, payload_len as u64);
-                    outbound.mark_sent();
+                    let (ack, ack_rx) = oneshot::channel();
+                    task_tx
+                        .send(WorkerTaskEvent::ResultPage {
+                            peer,
+                            session_epoch,
+                            outbound,
+                            ack,
+                        })
+                        .await
+                        .map_err(|_| worker_scheduler_gone_error())?;
+                    ack_rx.await.map_err(|_| worker_scheduler_gone_error())??;
                 }
                 Some(ResultPageStep::CloseFrame(frame)) => {
-                    debug!(
-                        component = "worker",
-                        session_epoch,
-                        peer = ?peer,
-                        "worker produced terminal result close frame"
-                    );
-                    let frame = encode_issued_frame(frame).map_err(|err| {
-                        WorkerRuntimeError::ProtocolViolation(format!(
-                            "failed to encode result close frame: {err}"
-                        ))
-                    })?;
-                    transport.send_peer_bytes(peer, &frame)?;
+                    let (ack, ack_rx) = oneshot::channel();
+                    task_tx
+                        .send(WorkerTaskEvent::ResultClose {
+                            peer,
+                            session_epoch,
+                            frame,
+                            ack,
+                        })
+                        .await
+                        .map_err(|_| worker_scheduler_gone_error())?;
+                    ack_rx.await.map_err(|_| worker_scheduler_gone_error())??;
                 }
                 None => break,
             }
@@ -991,6 +1538,18 @@ async fn execute_physical_plan(
     cleanup_result?;
 
     Ok(())
+}
+
+fn worker_scheduler_gone_error() -> WorkerRuntimeError {
+    WorkerRuntimeError::ProtocolViolation(
+        "worker scheduler stopped while execution task ran".into(),
+    )
+}
+
+fn stale_execution_task_error(peer: BackendLeaseSlot, session_epoch: u64) -> WorkerRuntimeError {
+    WorkerRuntimeError::ProtocolViolation(format!(
+        "stale execution task result ignored for peer {peer:?} session {session_epoch}"
+    ))
 }
 
 fn cleanup_execution_spill_dir(

--- a/pg/frontend/src/adapter/pg17/functions.rs
+++ b/pg/frontend/src/adapter/pg17/functions.rs
@@ -209,6 +209,7 @@ fn expr_pg_type(expr: &QueryExpr) -> Option<u32> {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
 

--- a/pg/frontend/src/compiler/expr.rs
+++ b/pg/frontend/src/compiler/expr.rs
@@ -358,9 +358,7 @@ pub(super) fn compile_cast(
 }
 
 fn text_typmod_cast_udf(pg_type: pg_type::PgTypeRef) -> Option<Arc<ScalarUDF>> {
-    if pg_type::text_typmod_length(pg_type.typmod).is_none() {
-        return None;
-    }
+    pg_type::text_typmod_length(pg_type.typmod)?;
     if pg_type.oid == u32::from(pgrx::pg_sys::VARCHAROID) {
         return Some(df_functions::pg_varchar_typmod_udf());
     }
@@ -637,6 +635,7 @@ pub(super) fn compile_array_subscript(
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn compile_scalar_function(
     func: ScalarFunction,
     args: &[QueryExpr],

--- a/pg/frontend/src/compiler/from.rs
+++ b/pg/frontend/src/compiler/from.rs
@@ -396,10 +396,7 @@ pub(super) fn function_call_needs_pg_text_semantics(
         return false;
     }
 
-    match func {
-        ScalarFunction::Length => false,
-        _ => true,
-    }
+    !matches!(func, ScalarFunction::Length)
 }
 
 pub(super) fn pg_text_cast_needs_pg_semantics(pg_type: pg_type::PgTypeRef) -> bool {

--- a/pg/test/src/backend_service.rs
+++ b/pg/test/src/backend_service.rs
@@ -535,7 +535,7 @@ fn begin_and_finalize_execution(
     let plan_transport = IssuedTransportHarness::new();
     let plan_rx = plan_transport.rx();
     let begin = BackendService::begin_execution(StartExecutionInput {
-        slot_id,
+        primary_peer: BackendLeaseSlot::new(slot_id, BackendLeaseId::new(1, 1)),
         plan_source: encoded_plan_source(&encoded),
         plan_tx: plan_transport.tx(),
         scan_slot_region: scan_slots,

--- a/pg/type/src/numeric.rs
+++ b/pg/type/src/numeric.rs
@@ -251,7 +251,7 @@ pub fn decimal128_to_numeric_varlena(
         if magnitude == 0 {
             dscale = 0;
         } else {
-            while dscale > 0 && magnitude % 10 == 0 {
+            while dscale > 0 && magnitude.is_multiple_of(10) {
                 magnitude /= 10;
                 dscale -= 1;
             }

--- a/runtime/control_transport/src/region/layout.rs
+++ b/runtime/control_transport/src/region/layout.rs
@@ -244,7 +244,7 @@ pub(super) fn validate_region(
     expected: usize,
 ) -> Result<(), (usize, usize, bool)> {
     let actual = base.as_ptr() as usize;
-    if actual % align != 0 {
+    if !actual.is_multiple_of(align) {
         return Err((align, actual, false));
     }
     if len < expected {

--- a/runtime/filter/Cargo.toml
+++ b/runtime/filter/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["lib"]
 doctest = false
 
 [dependencies]
+control_transport = { path = "../control_transport", version = "25.0" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/runtime/filter/README.md
+++ b/runtime/filter/README.md
@@ -25,7 +25,9 @@ The crate is split into three layers:
 - `RuntimeFilterPool` adds fixed-slot shared-memory ownership metadata and
   probe reference counts. It maps `(RuntimeFilterExecId, scan_id,
   output_column, key_type)` to a lifecycle slot and delays storage reuse until
-  the owner and all probe handles are gone.
+  the owner and all probe handles are gone. Slot state, refcount, and
+  publication epoch are one packed atomic word, so a probe can only acquire a
+  ref for the exact slot publication it observed.
 
 This keeps the filter payload reusable while avoiding false negatives from
 clearing storage under old probes or letting stale builders overwrite newer
@@ -128,6 +130,8 @@ sites.
 
 - Never apply a filter while it is `Building`; that can create false negatives.
 - Never clear/reuse Bloom storage until every old probe reference is gone.
+- Never acquire a pool probe ref with separate state/refcount atomics; the
+  packed publication word is the incarnation guard.
 - Stale builders must not publish or disable newer generations.
 - Missing, disabled, stale, or exhausted filters must pass rows unfiltered.
 - Null probe values are `DefinitelyAbsent` only for a matching `Ready`

--- a/runtime/filter/README.md
+++ b/runtime/filter/README.md
@@ -23,9 +23,9 @@ The crate is split into three layers:
   Probes reject rows only when their expected generation is currently `Ready`;
   all stale, free, building, or disabled states pass rows unfiltered.
 - `RuntimeFilterPool` adds fixed-slot shared-memory ownership metadata and
-  probe reference counts. It maps `(session_epoch, scan_id, output_column,
-  key_type)` to a lifecycle slot and delays storage reuse until the owner and
-  all probe handles are gone.
+  probe reference counts. It maps `(RuntimeFilterExecId, scan_id,
+  output_column, key_type)` to a lifecycle slot and delays storage reuse until
+  the owner and all probe handles are gone.
 
 This keeps the filter payload reusable while avoiding false negatives from
 clearing storage under old probes or letting stale builders overwrite newer
@@ -59,7 +59,7 @@ still be reading Bloom words.
    region with the returned size/alignment.
 2. Startup code initializes the region with `RuntimeFilterPool::init_in_place`.
 3. Workers attach and call `allocate_build(target)` for a specific scan target.
-4. Backends attach and call `lookup_probes(session_epoch, scan_id, &mut probes)`.
+4. Backends attach and call `lookup_probes(exec_id, scan_id, &mut probes)`.
 5. Build and probe handles release references on drop; the pool retires and
    frees a slot only after the owner and all probes have gone away.
 
@@ -71,7 +71,7 @@ is a performance miss, not a correctness failure.
 ```rust
 use filter::{
     BloomParams, ProbeDecision, RuntimeFilterPool, RuntimeFilterPoolConfig,
-    RuntimeFilterTarget, RuntimeFilterKeyType, hash_int_key,
+    RuntimeFilterExecId, RuntimeFilterTarget, RuntimeFilterKeyType, hash_int_key,
 };
 
 # fn example(region: *mut u8, region_len: usize) -> Result<(), Box<dyn std::error::Error>> {
@@ -81,8 +81,9 @@ let config = RuntimeFilterPoolConfig::new(64, params);
 // Startup path initializes the caller-owned shared-memory region.
 let pool = unsafe { RuntimeFilterPool::init_in_place(region, region_len, config)? };
 
+let exec_id = RuntimeFilterExecId::new(1, 2, 3, 7);
 let target = RuntimeFilterTarget {
-    session_epoch: 7,
+    exec_id,
     scan_id: 42,
     output_column: 3,
     key_type: RuntimeFilterKeyType::Int64,
@@ -94,7 +95,7 @@ if let Some(build) = pool.allocate_build(target)? {
 }
 
 let mut probes = Vec::new();
-pool.lookup_probes(7, 42, &mut probes);
+pool.lookup_probes(exec_id, 42, &mut probes);
 for probe in &probes {
     if probe.decision_for_hash(hash_int_key(11)) == ProbeDecision::DefinitelyAbsent {
         // The row can be skipped before expensive decode/encode work.

--- a/runtime/filter/spec/README.md
+++ b/runtime/filter/spec/README.md
@@ -1,6 +1,6 @@
 # Runtime filter specs
 
-`RuntimeFilterLifecycle.tla` models the shared-memory lifecycle used by
+`RuntimeFilterLifecycle.tla` models the shared-memory Bloom lifecycle used by
 opportunistic runtime filters.
 
 The model intentionally treats Bloom bits abstractly as a set of inserted keys.
@@ -14,10 +14,38 @@ quiescence boundary: the low-level API exposes it as unsafe because active
 probes cannot be tracked by the Bloom bits themselves, while `RuntimeFilterPool`
 tracks probe refs before reusing storage.
 
-Smoke run:
+`RuntimeFilterPoolPublication.tla` models the pool-level publication protocol
+around one shared slot. This is the layer that keeps a slot unprobeable while
+`RuntimeFilterPool::allocate_build` initializes target metadata, then publishes
+it with one packed `SLOT_ALLOCATED` word containing the owner ref and
+publication epoch. The model checks that probes can attach only after
+publication, delayed lookups cannot mutate a reused epoch, initializing slots
+cannot gain probe refs, failed initialization rolls back to a clean free slot,
+and retiring slots are reused only after all refs are gone.
+
+The split is intentional: the lifecycle spec is about Bloom readiness and
+false-negative safety; the publication spec is about the intermediate
+multi-step pool protocol that the Rust implementation refines. Rust-side
+coverage for this publication seam lives in the deterministic
+`initializing_pool_slot_is_invisible_to_probe_lookup` unit test and the
+`pool_initializing_state_blocks_probe_refcount_race` and
+`stale_observed_probe_cannot_mutate_reused_pool_slot` loom tests.
+
+SANY checks:
 
 ```sh
-java -cp "$TLA_JAR" tlc2.TLC -deadlock -cleanup -workers 1 \
+~/script/tla/tla sany runtime/filter/spec/RuntimeFilterLifecycle.tla
+~/script/tla/tla sany runtime/filter/spec/RuntimeFilterPoolPublication.tla
+```
+
+Smoke runs:
+
+```sh
+~/script/tla/tla tlc -deadlock -cleanup -workers 1 \
   -config runtime/filter/spec/RuntimeFilterLifecycle.cfg \
   runtime/filter/spec/RuntimeFilterLifecycle.tla
+
+~/script/tla/tla tlc -deadlock -cleanup -workers 1 \
+  -config runtime/filter/spec/RuntimeFilterPoolPublication.cfg \
+  runtime/filter/spec/RuntimeFilterPoolPublication.tla
 ```

--- a/runtime/filter/spec/RuntimeFilterPoolPublication.cfg
+++ b/runtime/filter/spec/RuntimeFilterPoolPublication.cfg
@@ -1,0 +1,16 @@
+CONSTANTS
+    MaxProbeRefs = 2
+    MaxEpoch = 3
+
+INIT Init
+NEXT Next
+
+INVARIANTS
+    TypeInvariant
+    RefAccounting
+    FreeClean
+    InitializingUnprobeable
+    PublishedMetadata
+    AllocatedHasOwner
+    RetiringHasNoOwner
+    LookupAttachOnlyCurrentPublication

--- a/runtime/filter/spec/RuntimeFilterPoolPublication.tla
+++ b/runtime/filter/spec/RuntimeFilterPoolPublication.tla
@@ -1,0 +1,195 @@
+---- MODULE RuntimeFilterPoolPublication ----
+EXTENDS Naturals
+
+CONSTANTS MaxProbeRefs, MaxEpoch
+
+PoolStates == {"Free", "Initializing", "Allocated", "Retiring"}
+LookupResults == {"None", "Blocked", "Observed", "Attached", "Miss", "Stale"}
+NoPending == MaxEpoch + 1
+OptionEpoch == 0..NoPending
+
+VARIABLES poolState, epoch, ownerLive, metadataInit, refs, probeRefs,
+          pendingLookupEpoch, lastLookup
+
+vars == <<poolState, epoch, ownerLive, metadataInit, refs, probeRefs,
+          pendingLookupEpoch, lastLookup>>
+
+Init ==
+    /\ poolState = "Free"
+    /\ epoch = 0
+    /\ ownerLive = FALSE
+    /\ metadataInit = FALSE
+    /\ refs = 0
+    /\ probeRefs = 0
+    /\ pendingLookupEpoch = NoPending
+    /\ lastLookup = "None"
+
+\* The worker claims a pool slot before target metadata and the owner ref are
+\* visible to probes.  This state corresponds to SLOT_INITIALIZING.
+BeginInitialize ==
+    /\ poolState = "Free"
+    /\ epoch < MaxEpoch
+    /\ poolState' = "Initializing"
+    /\ epoch' = epoch + 1
+    /\ ownerLive' = FALSE
+    /\ metadataInit' = FALSE
+    /\ refs' = 0
+    /\ probeRefs' = 0
+    /\ pendingLookupEpoch' = pendingLookupEpoch
+    /\ lastLookup' = "None"
+
+InstallMetadata ==
+    /\ poolState = "Initializing"
+    /\ ~metadataInit
+    /\ metadataInit' = TRUE
+    /\ UNCHANGED <<poolState, epoch, ownerLive, refs, probeRefs,
+                  pendingLookupEpoch, lastLookup>>
+
+\* Publication is the linearization point for lookup visibility.  Rust stores a
+\* packed SLOT_ALLOCATED word that includes the owner ref and publication epoch
+\* only after target metadata is initialized.
+PublishAllocated ==
+    /\ poolState = "Initializing"
+    /\ metadataInit
+    /\ poolState' = "Allocated"
+    /\ ownerLive' = TRUE
+    /\ refs' = 1
+    /\ lastLookup' = "None"
+    /\ UNCHANGED <<epoch, metadataInit, probeRefs, pendingLookupEpoch>>
+
+RollbackInitialize ==
+    /\ poolState = "Initializing"
+    /\ poolState' = "Free"
+    /\ ownerLive' = FALSE
+    /\ metadataInit' = FALSE
+    /\ refs' = 0
+    /\ probeRefs' = 0
+    /\ lastLookup' = "None"
+    /\ UNCHANGED <<epoch, pendingLookupEpoch>>
+
+\* A lookup may observe an allocated slot before attempting the refcount CAS.
+\* The observed epoch must match at the CAS point or the lookup is stale.
+ObserveAllocated ==
+    /\ pendingLookupEpoch = NoPending
+    /\ poolState = "Allocated"
+    /\ pendingLookupEpoch' = epoch
+    /\ lastLookup' = "Observed"
+    /\ UNCHANGED <<poolState, epoch, ownerLive, metadataInit, refs, probeRefs>>
+
+AttachObservedLookup ==
+    /\ pendingLookupEpoch # NoPending
+    /\ poolState = "Allocated"
+    /\ epoch = pendingLookupEpoch
+    /\ probeRefs < MaxProbeRefs
+    /\ refs' = refs + 1
+    /\ probeRefs' = probeRefs + 1
+    /\ pendingLookupEpoch' = NoPending
+    /\ lastLookup' = "Attached"
+    /\ UNCHANGED <<poolState, epoch, ownerLive, metadataInit>>
+
+StaleObservedLookup ==
+    /\ pendingLookupEpoch # NoPending
+    /\ \/ poolState # "Allocated"
+       \/ epoch # pendingLookupEpoch
+    /\ pendingLookupEpoch' = NoPending
+    /\ lastLookup' = "Stale"
+    /\ UNCHANGED <<poolState, epoch, ownerLive, metadataInit, refs, probeRefs>>
+
+\* A non-matching lookup that observes the current publication may acquire and
+\* release a temporary ref with no net abstract refcount change.
+LookupMiss ==
+    /\ pendingLookupEpoch = NoPending
+    /\ poolState = "Allocated"
+    /\ lastLookup' = "Miss"
+    /\ UNCHANGED <<poolState, epoch, ownerLive, metadataInit, refs, probeRefs,
+                  pendingLookupEpoch>>
+
+LookupBlocked ==
+    /\ pendingLookupEpoch = NoPending
+    /\ poolState # "Allocated"
+    /\ lastLookup' = "Blocked"
+    /\ UNCHANGED <<poolState, epoch, ownerLive, metadataInit, refs, probeRefs,
+                  pendingLookupEpoch>>
+
+ReleaseOwner ==
+    /\ ownerLive
+    /\ refs > 0
+    /\ poolState = "Allocated"
+    /\ ownerLive' = FALSE
+    /\ refs' = refs - 1
+    /\ poolState' = "Retiring"
+    /\ lastLookup' = "None"
+    /\ UNCHANGED <<epoch, metadataInit, probeRefs, pendingLookupEpoch>>
+
+ReleaseProbe ==
+    /\ probeRefs > 0
+    /\ refs' = refs - 1
+    /\ probeRefs' = probeRefs - 1
+    /\ lastLookup' = "None"
+    /\ UNCHANGED <<poolState, epoch, ownerLive, metadataInit,
+                  pendingLookupEpoch>>
+
+FinishRetire ==
+    /\ poolState = "Retiring"
+    /\ refs = 0
+    /\ probeRefs = 0
+    /\ ~ownerLive
+    /\ poolState' = "Free"
+    /\ metadataInit' = FALSE
+    /\ lastLookup' = "None"
+    /\ UNCHANGED <<epoch, ownerLive, refs, probeRefs, pendingLookupEpoch>>
+
+Next ==
+    \/ BeginInitialize
+    \/ InstallMetadata
+    \/ PublishAllocated
+    \/ RollbackInitialize
+    \/ ObserveAllocated
+    \/ AttachObservedLookup
+    \/ StaleObservedLookup
+    \/ LookupMiss
+    \/ LookupBlocked
+    \/ ReleaseOwner
+    \/ ReleaseProbe
+    \/ FinishRetire
+
+TypeInvariant ==
+    /\ poolState \in PoolStates
+    /\ epoch \in 0..MaxEpoch
+    /\ ownerLive \in BOOLEAN
+    /\ metadataInit \in BOOLEAN
+    /\ refs \in 0..(MaxProbeRefs + 1)
+    /\ probeRefs \in 0..MaxProbeRefs
+    /\ pendingLookupEpoch \in OptionEpoch
+    /\ lastLookup \in LookupResults
+
+RefAccounting ==
+    refs = probeRefs + (IF ownerLive THEN 1 ELSE 0)
+
+FreeClean ==
+    poolState = "Free" => /\ refs = 0
+                          /\ probeRefs = 0
+                          /\ ~ownerLive
+                          /\ ~metadataInit
+
+InitializingUnprobeable ==
+    poolState = "Initializing" => probeRefs = 0
+
+PublishedMetadata ==
+    poolState \in {"Allocated", "Retiring"} => metadataInit
+
+AllocatedHasOwner ==
+    poolState = "Allocated" => /\ ownerLive
+                               /\ refs >= 1
+
+RetiringHasNoOwner ==
+    poolState = "Retiring" => /\ ~ownerLive
+                              /\ refs = probeRefs
+
+LookupAttachOnlyCurrentPublication ==
+    lastLookup = "Attached" => /\ poolState = "Allocated"
+                               /\ pendingLookupEpoch = NoPending
+
+Spec == Init /\ [][Next]_vars
+
+====

--- a/runtime/filter/src/lib.rs
+++ b/runtime/filter/src/lib.rs
@@ -12,7 +12,7 @@ pub use bloom::{
     BloomParams, RuntimeFilterLayout,
 };
 pub use pool::{
-    RuntimeFilterBuildHandle, RuntimeFilterKeyType, RuntimeFilterPool,
+    RuntimeFilterBuildHandle, RuntimeFilterExecId, RuntimeFilterKeyType, RuntimeFilterPool,
     RuntimeFilterPoolAttachError, RuntimeFilterPoolConfig, RuntimeFilterPoolLayout,
     RuntimeFilterProbeHandle, RuntimeFilterTarget, RUNTIME_FILTER_POOL_VERSION,
 };

--- a/runtime/filter/src/pool.rs
+++ b/runtime/filter/src/pool.rs
@@ -13,12 +13,22 @@ use crate::{
 
 const POOL_MAGIC: u64 = 0x5047_4655_5246_5031;
 /// Shared-memory pool format version.
-pub const RUNTIME_FILTER_POOL_VERSION: u32 = 2;
+pub const RUNTIME_FILTER_POOL_VERSION: u32 = 3;
 
-const SLOT_FREE: u32 = 0;
-const SLOT_INITIALIZING: u32 = 1;
-const SLOT_ALLOCATED: u32 = 2;
-const SLOT_RETIRING: u32 = 3;
+const SLOT_FREE: u64 = 0;
+const SLOT_INITIALIZING: u64 = 1;
+const SLOT_ALLOCATED: u64 = 2;
+const SLOT_RETIRING: u64 = 3;
+
+const SLOT_STATE_BITS: u32 = 2;
+const SLOT_REF_BITS: u32 = 16;
+const SLOT_REF_SHIFT: u32 = SLOT_STATE_BITS;
+const SLOT_EPOCH_SHIFT: u32 = SLOT_STATE_BITS + SLOT_REF_BITS;
+const SLOT_STATE_MASK: u64 = (1u64 << SLOT_STATE_BITS) - 1;
+const SLOT_REF_MASK: u64 = (1u64 << SLOT_REF_BITS) - 1;
+const SLOT_EPOCH_MASK: u64 = (1u64 << (64 - SLOT_EPOCH_SHIFT)) - 1;
+const SLOT_MAX_REFS: u32 = SLOT_REF_MASK as u32;
+const SLOT_MAX_EPOCH: u64 = SLOT_EPOCH_MASK;
 
 /// Runtime-filter key types currently supported by pg_fusion scan probes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -249,8 +259,7 @@ struct PoolHeader {
 
 #[repr(C)]
 struct PoolSlot {
-    state: AtomicU32,
-    refs: AtomicU32,
+    meta: AtomicU64,
     generation: AtomicU64,
     exec_slot_id: AtomicU32,
     exec_generation: AtomicU64,
@@ -265,8 +274,7 @@ struct PoolSlot {
 impl PoolSlot {
     fn new() -> Self {
         Self {
-            state: AtomicU32::new(SLOT_FREE),
-            refs: AtomicU32::new(0),
+            meta: AtomicU64::new(pack_pool_word(SLOT_FREE, 0, 0)),
             generation: AtomicU64::new(0),
             exec_slot_id: AtomicU32::new(0),
             exec_generation: AtomicU64::new(0),
@@ -276,6 +284,67 @@ impl PoolSlot {
             output_column: AtomicU32::new(0),
             key_type: AtomicU32::new(0),
             header: RuntimeFilterHeader::free(),
+        }
+    }
+}
+
+fn pack_pool_word(state: u64, refs: u32, publication_epoch: u64) -> u64 {
+    debug_assert!(state <= SLOT_STATE_MASK);
+    debug_assert!((refs as u64) <= SLOT_REF_MASK);
+    debug_assert!(publication_epoch <= SLOT_EPOCH_MASK);
+    state | ((refs as u64) << SLOT_REF_SHIFT) | (publication_epoch << SLOT_EPOCH_SHIFT)
+}
+
+fn pool_word_state(word: u64) -> u64 {
+    word & SLOT_STATE_MASK
+}
+
+fn pool_word_refs(word: u64) -> u32 {
+    ((word >> SLOT_REF_SHIFT) & SLOT_REF_MASK) as u32
+}
+
+fn pool_word_epoch(word: u64) -> u64 {
+    (word >> SLOT_EPOCH_SHIFT) & SLOT_EPOCH_MASK
+}
+
+fn claim_initializing_slot(slot: &PoolSlot) -> Option<u64> {
+    let mut current = slot.meta.load(Ordering::Acquire);
+    loop {
+        if pool_word_state(current) != SLOT_FREE || pool_word_refs(current) != 0 {
+            return None;
+        }
+        let publication_epoch = pool_word_epoch(current).checked_add(1)?;
+        if publication_epoch > SLOT_MAX_EPOCH {
+            return None;
+        }
+        let next = pack_pool_word(SLOT_INITIALIZING, 0, publication_epoch);
+        match slot
+            .meta
+            .compare_exchange(current, next, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => return Some(publication_epoch),
+            Err(actual) => current = actual,
+        }
+    }
+}
+
+fn acquire_probe_ref(slot: &PoolSlot) -> bool {
+    let mut current = slot.meta.load(Ordering::Acquire);
+    loop {
+        if pool_word_state(current) != SLOT_ALLOCATED {
+            return false;
+        }
+        let refs = pool_word_refs(current);
+        if refs == SLOT_MAX_REFS {
+            return false;
+        }
+        let next = pack_pool_word(SLOT_ALLOCATED, refs + 1, pool_word_epoch(current));
+        match slot
+            .meta
+            .compare_exchange(current, next, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => return true,
+            Err(actual) => current = actual,
         }
     }
 }
@@ -476,20 +545,10 @@ impl RuntimeFilterPool {
 
         for slot_index in 0..self.config.slot_count {
             let slot = unsafe { self.slot(slot_index) };
-            if slot
-                .state
-                .compare_exchange(
-                    SLOT_FREE,
-                    SLOT_INITIALIZING,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                )
-                .is_err()
-            {
+            let Some(publication_epoch) = claim_initializing_slot(slot) else {
                 continue;
-            }
+            };
 
-            slot.refs.store(1, Ordering::Release);
             store_exec_id(slot, target.exec_id);
             slot.scan_id.store(target.scan_id, Ordering::Release);
             slot.output_column
@@ -503,7 +562,10 @@ impl RuntimeFilterPool {
                 Ok(builder) => {
                     let generation = builder.detach();
                     slot.generation.store(generation, Ordering::Release);
-                    slot.state.store(SLOT_ALLOCATED, Ordering::Release);
+                    slot.meta.store(
+                        pack_pool_word(SLOT_ALLOCATED, 1, publication_epoch),
+                        Ordering::Release,
+                    );
                     return Ok(Some(RuntimeFilterBuildHandle {
                         pool: self,
                         slot_index,
@@ -512,9 +574,11 @@ impl RuntimeFilterPool {
                     }));
                 }
                 Err(err) => {
-                    slot.refs.store(0, Ordering::Release);
                     clear_slot_metadata(slot);
-                    slot.state.store(SLOT_FREE, Ordering::Release);
+                    slot.meta.store(
+                        pack_pool_word(SLOT_FREE, 0, publication_epoch),
+                        Ordering::Release,
+                    );
                     return Err(err);
                 }
             }
@@ -539,15 +603,12 @@ impl RuntimeFilterPool {
 
         for slot_index in 0..self.config.slot_count {
             let slot = unsafe { self.slot(slot_index) };
-            if slot.state.load(Ordering::Acquire) != SLOT_ALLOCATED {
+            if !acquire_probe_ref(slot) {
                 continue;
             }
-            slot.refs.fetch_add(1, Ordering::AcqRel);
 
-            let state = slot.state.load(Ordering::Acquire);
-            let matches = state == SLOT_ALLOCATED
-                && load_exec_id(slot) == exec_id
-                && slot.scan_id.load(Ordering::Acquire) == scan_id;
+            let matches =
+                load_exec_id(slot) == exec_id && slot.scan_id.load(Ordering::Acquire) == scan_id;
             if !matches {
                 self.release_ref(slot_index);
                 continue;
@@ -608,52 +669,120 @@ impl RuntimeFilterPool {
 
     fn release_owner(self, slot_index: u32) {
         let slot = unsafe { self.slot(slot_index) };
-        let _ = slot.state.compare_exchange(
-            SLOT_ALLOCATED,
-            SLOT_RETIRING,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        );
-        self.release_ref(slot_index);
+        let mut current = slot.meta.load(Ordering::Acquire);
+        loop {
+            if pool_word_state(current) != SLOT_ALLOCATED {
+                return;
+            }
+            let refs = pool_word_refs(current);
+            if refs == 0 {
+                debug_assert!(refs > 0, "allocated runtime filter slot has no owner ref");
+                return;
+            }
+
+            let next_refs = refs - 1;
+            let publication_epoch = pool_word_epoch(current);
+            let next = pack_pool_word(SLOT_RETIRING, next_refs, publication_epoch);
+            match slot
+                .meta
+                .compare_exchange(current, next, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => {
+                    if next_refs == 0 {
+                        self.finish_retire(slot_index, publication_epoch);
+                    }
+                    return;
+                }
+                Err(actual) => current = actual,
+            }
+        }
     }
 
     fn release_ref(self, slot_index: u32) {
         let slot = unsafe { self.slot(slot_index) };
-        let old_refs = slot.refs.fetch_sub(1, Ordering::AcqRel);
-        debug_assert!(old_refs > 0);
-        if old_refs == 1 && slot.state.load(Ordering::Acquire) == SLOT_RETIRING {
-            let generation = slot.generation.load(Ordering::Acquire);
-            if let Ok(runtime_slot) = unsafe { self.runtime_slot(slot_index) } {
-                match runtime_slot.snapshot().state {
-                    RuntimeFilterState::Ready => {
-                        // SAFETY: this is the last pool reference after the
-                        // owner entered RETIRING, so no old probe can still be
-                        // inside a bit read and no new probe can attach.
-                        let _ = unsafe { runtime_slot.retire_ready_after_quiescence(generation) };
-                    }
-                    RuntimeFilterState::Building => {
-                        let _ = runtime_slot.disable_build(generation);
-                    }
-                    RuntimeFilterState::Free | RuntimeFilterState::Disabled => {}
-                }
+        let mut current = slot.meta.load(Ordering::Acquire);
+        loop {
+            let state = pool_word_state(current);
+            if state != SLOT_ALLOCATED && state != SLOT_RETIRING {
+                debug_assert!(
+                    state == SLOT_ALLOCATED || state == SLOT_RETIRING,
+                    "runtime filter ref released from inactive slot",
+                );
+                return;
             }
-            clear_slot_metadata(slot);
-            slot.state.store(SLOT_FREE, Ordering::Release);
+            let refs = pool_word_refs(current);
+            if refs == 0 {
+                debug_assert!(refs > 0, "runtime filter reference count underflowed");
+                return;
+            }
+            debug_assert!(
+                state != SLOT_ALLOCATED || refs > 1,
+                "allocated runtime filter slot lost owner ref",
+            );
+
+            let next_refs = refs - 1;
+            let publication_epoch = pool_word_epoch(current);
+            let next = pack_pool_word(state, next_refs, publication_epoch);
+            match slot
+                .meta
+                .compare_exchange(current, next, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => {
+                    if state == SLOT_RETIRING && next_refs == 0 {
+                        self.finish_retire(slot_index, publication_epoch);
+                    }
+                    return;
+                }
+                Err(actual) => current = actual,
+            }
         }
+    }
+
+    fn finish_retire(self, slot_index: u32, publication_epoch: u64) {
+        let slot = unsafe { self.slot(slot_index) };
+        debug_assert_eq!(
+            slot.meta.load(Ordering::Acquire),
+            pack_pool_word(SLOT_RETIRING, 0, publication_epoch),
+        );
+        let generation = slot.generation.load(Ordering::Acquire);
+        if let Ok(runtime_slot) = unsafe { self.runtime_slot(slot_index) } {
+            match runtime_slot.snapshot().state {
+                RuntimeFilterState::Ready => {
+                    // SAFETY: this is the last pool reference after the owner
+                    // entered RETIRING, so no old probe can still be inside a
+                    // bit read and no new probe can attach.
+                    let _ = unsafe { runtime_slot.retire_ready_after_quiescence(generation) };
+                }
+                RuntimeFilterState::Building => {
+                    let _ = runtime_slot.disable_build(generation);
+                }
+                RuntimeFilterState::Free | RuntimeFilterState::Disabled => {}
+            }
+        }
+        clear_slot_metadata(slot);
+        slot.meta.store(
+            pack_pool_word(SLOT_FREE, 0, publication_epoch),
+            Ordering::Release,
+        );
     }
 
     #[cfg(test)]
     pub(crate) fn initialize_slot_for_test(self, slot_index: u32, target: RuntimeFilterTarget) {
         let slot = unsafe { self.slot(slot_index) };
-        slot.state
+        let current = slot.meta.load(Ordering::Acquire);
+        assert_eq!(pool_word_state(current), SLOT_FREE);
+        assert_eq!(pool_word_refs(current), 0);
+        let publication_epoch = pool_word_epoch(current)
+            .checked_add(1)
+            .expect("test publication epoch should not overflow");
+        slot.meta
             .compare_exchange(
-                SLOT_FREE,
-                SLOT_INITIALIZING,
+                current,
+                pack_pool_word(SLOT_INITIALIZING, 0, publication_epoch),
                 Ordering::AcqRel,
                 Ordering::Acquire,
             )
             .expect("test slot should be free");
-        slot.refs.store(1, Ordering::Release);
         store_exec_id(slot, target.exec_id);
         slot.scan_id.store(target.scan_id, Ordering::Release);
         slot.output_column
@@ -665,7 +794,7 @@ impl RuntimeFilterPool {
     #[cfg(test)]
     pub(crate) fn refs_for_test(self, slot_index: u32) -> u32 {
         let slot = unsafe { self.slot(slot_index) };
-        slot.refs.load(Ordering::Acquire)
+        pool_word_refs(slot.meta.load(Ordering::Acquire))
     }
 
     unsafe fn slot(self, slot_index: u32) -> &'static PoolSlot {

--- a/runtime/filter/src/pool.rs
+++ b/runtime/filter/src/pool.rs
@@ -4,6 +4,8 @@ use std::fmt;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
+use control_transport::BackendLeaseSlot;
+
 use crate::{
     AtomicBloomRef, BloomAttachError, BloomParams, LifecycleError, ProbeDecision,
     RuntimeFilterHeader, RuntimeFilterSlot, RuntimeFilterState,
@@ -11,11 +13,12 @@ use crate::{
 
 const POOL_MAGIC: u64 = 0x5047_4655_5246_5031;
 /// Shared-memory pool format version.
-pub const RUNTIME_FILTER_POOL_VERSION: u32 = 1;
+pub const RUNTIME_FILTER_POOL_VERSION: u32 = 2;
 
 const SLOT_FREE: u32 = 0;
-const SLOT_ALLOCATED: u32 = 1;
-const SLOT_RETIRING: u32 = 2;
+const SLOT_INITIALIZING: u32 = 1;
+const SLOT_ALLOCATED: u32 = 2;
+const SLOT_RETIRING: u32 = 3;
 
 /// Runtime-filter key types currently supported by pg_fusion scan probes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -73,11 +76,60 @@ impl RuntimeFilterKeyType {
     }
 }
 
+/// Execution namespace for runtime-filter targets.
+///
+/// Backend-local session epochs are unique only within one primary backend
+/// lease. Runtime filters need the full primary lease identity so concurrent
+/// backend executions cannot attach to each other's filters.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct RuntimeFilterExecId {
+    slot_id: u32,
+    generation: u64,
+    lease_epoch: u64,
+    session_epoch: u64,
+}
+
+impl RuntimeFilterExecId {
+    pub const fn new(slot_id: u32, generation: u64, lease_epoch: u64, session_epoch: u64) -> Self {
+        Self {
+            slot_id,
+            generation,
+            lease_epoch,
+            session_epoch,
+        }
+    }
+
+    pub const fn from_peer(peer: BackendLeaseSlot, session_epoch: u64) -> Self {
+        Self::new(
+            peer.slot_id(),
+            peer.lease_id().generation(),
+            peer.lease_id().lease_epoch(),
+            session_epoch,
+        )
+    }
+
+    pub const fn slot_id(self) -> u32 {
+        self.slot_id
+    }
+
+    pub const fn generation(self) -> u64 {
+        self.generation
+    }
+
+    pub const fn lease_epoch(self) -> u64 {
+        self.lease_epoch
+    }
+
+    pub const fn session_epoch(self) -> u64 {
+        self.session_epoch
+    }
+}
+
 /// Logical target that connects a worker-built filter to backend scan probes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RuntimeFilterTarget {
-    /// Session epoch that scopes scan identifiers.
-    pub session_epoch: u64,
+    /// Execution namespace that scopes scan identifiers.
+    pub exec_id: RuntimeFilterExecId,
     /// Backend scan identifier.
     pub scan_id: u64,
     /// Output column to inspect before tuple-to-Arrow encoding.
@@ -200,7 +252,10 @@ struct PoolSlot {
     state: AtomicU32,
     refs: AtomicU32,
     generation: AtomicU64,
-    session_epoch: AtomicU64,
+    exec_slot_id: AtomicU32,
+    exec_generation: AtomicU64,
+    exec_lease_epoch: AtomicU64,
+    exec_session_epoch: AtomicU64,
     scan_id: AtomicU64,
     output_column: AtomicU32,
     key_type: AtomicU32,
@@ -213,7 +268,10 @@ impl PoolSlot {
             state: AtomicU32::new(SLOT_FREE),
             refs: AtomicU32::new(0),
             generation: AtomicU64::new(0),
-            session_epoch: AtomicU64::new(0),
+            exec_slot_id: AtomicU32::new(0),
+            exec_generation: AtomicU64::new(0),
+            exec_lease_epoch: AtomicU64::new(0),
+            exec_session_epoch: AtomicU64::new(0),
             scan_id: AtomicU64::new(0),
             output_column: AtomicU32::new(0),
             key_type: AtomicU32::new(0),
@@ -422,7 +480,7 @@ impl RuntimeFilterPool {
                 .state
                 .compare_exchange(
                     SLOT_FREE,
-                    SLOT_ALLOCATED,
+                    SLOT_INITIALIZING,
                     Ordering::AcqRel,
                     Ordering::Acquire,
                 )
@@ -432,19 +490,20 @@ impl RuntimeFilterPool {
             }
 
             slot.refs.store(1, Ordering::Release);
-            slot.session_epoch
-                .store(target.session_epoch, Ordering::Release);
+            store_exec_id(slot, target.exec_id);
             slot.scan_id.store(target.scan_id, Ordering::Release);
             slot.output_column
                 .store(target.output_column, Ordering::Release);
             slot.key_type
                 .store(target.key_type as u32, Ordering::Release);
 
-            let runtime_slot = unsafe { self.runtime_slot(slot_index)? };
-            match runtime_slot.try_acquire_builder() {
+            let builder_result = unsafe { self.runtime_slot(slot_index) }
+                .and_then(|runtime_slot| runtime_slot.try_acquire_builder().map_err(Into::into));
+            match builder_result {
                 Ok(builder) => {
                     let generation = builder.detach();
                     slot.generation.store(generation, Ordering::Release);
+                    slot.state.store(SLOT_ALLOCATED, Ordering::Release);
                     return Ok(Some(RuntimeFilterBuildHandle {
                         pool: self,
                         slot_index,
@@ -454,8 +513,9 @@ impl RuntimeFilterPool {
                 }
                 Err(err) => {
                     slot.refs.store(0, Ordering::Release);
+                    clear_slot_metadata(slot);
                     slot.state.store(SLOT_FREE, Ordering::Release);
-                    return Err(err.into());
+                    return Err(err);
                 }
             }
         }
@@ -463,13 +523,13 @@ impl RuntimeFilterPool {
         Ok(None)
     }
 
-    /// Find probe handles matching `(session_epoch, scan_id)`.
+    /// Find probe handles matching `(exec_id, scan_id)`.
     ///
     /// Matching handles are pushed into `probes` and hold pool references until
     /// dropped.
     pub fn lookup_probes(
         self,
-        session_epoch: u64,
+        exec_id: RuntimeFilterExecId,
         scan_id: u64,
         probes: &mut Vec<RuntimeFilterProbeHandle>,
     ) {
@@ -486,7 +546,7 @@ impl RuntimeFilterPool {
 
             let state = slot.state.load(Ordering::Acquire);
             let matches = state == SLOT_ALLOCATED
-                && slot.session_epoch.load(Ordering::Acquire) == session_epoch
+                && load_exec_id(slot) == exec_id
                 && slot.scan_id.load(Ordering::Acquire) == scan_id;
             if !matches {
                 self.release_ref(slot_index);
@@ -577,13 +637,35 @@ impl RuntimeFilterPool {
                     RuntimeFilterState::Free | RuntimeFilterState::Disabled => {}
                 }
             }
-            slot.session_epoch.store(0, Ordering::Release);
-            slot.scan_id.store(0, Ordering::Release);
-            slot.output_column.store(0, Ordering::Release);
-            slot.key_type.store(0, Ordering::Release);
-            slot.generation.store(0, Ordering::Release);
+            clear_slot_metadata(slot);
             slot.state.store(SLOT_FREE, Ordering::Release);
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn initialize_slot_for_test(self, slot_index: u32, target: RuntimeFilterTarget) {
+        let slot = unsafe { self.slot(slot_index) };
+        slot.state
+            .compare_exchange(
+                SLOT_FREE,
+                SLOT_INITIALIZING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .expect("test slot should be free");
+        slot.refs.store(1, Ordering::Release);
+        store_exec_id(slot, target.exec_id);
+        slot.scan_id.store(target.scan_id, Ordering::Release);
+        slot.output_column
+            .store(target.output_column, Ordering::Release);
+        slot.key_type
+            .store(target.key_type as u32, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn refs_for_test(self, slot_index: u32) -> u32 {
+        let slot = unsafe { self.slot(slot_index) };
+        slot.refs.load(Ordering::Acquire)
     }
 
     unsafe fn slot(self, slot_index: u32) -> &'static PoolSlot {
@@ -618,6 +700,38 @@ impl RuntimeFilterPool {
             self.config.params,
         )?)
     }
+}
+
+fn store_exec_id(slot: &PoolSlot, exec_id: RuntimeFilterExecId) {
+    slot.exec_slot_id
+        .store(exec_id.slot_id(), Ordering::Release);
+    slot.exec_generation
+        .store(exec_id.generation(), Ordering::Release);
+    slot.exec_lease_epoch
+        .store(exec_id.lease_epoch(), Ordering::Release);
+    slot.exec_session_epoch
+        .store(exec_id.session_epoch(), Ordering::Release);
+}
+
+fn load_exec_id(slot: &PoolSlot) -> RuntimeFilterExecId {
+    RuntimeFilterExecId::new(
+        slot.exec_slot_id.load(Ordering::Acquire),
+        slot.exec_generation.load(Ordering::Acquire),
+        slot.exec_lease_epoch.load(Ordering::Acquire),
+        slot.exec_session_epoch.load(Ordering::Acquire),
+    )
+}
+
+fn clear_exec_id(slot: &PoolSlot) {
+    store_exec_id(slot, RuntimeFilterExecId::default());
+}
+
+fn clear_slot_metadata(slot: &PoolSlot) {
+    clear_exec_id(slot);
+    slot.scan_id.store(0, Ordering::Release);
+    slot.output_column.store(0, Ordering::Release);
+    slot.key_type.store(0, Ordering::Release);
+    slot.generation.store(0, Ordering::Release);
 }
 
 #[derive(Debug)]

--- a/runtime/filter/src/tests.rs
+++ b/runtime/filter/src/tests.rs
@@ -561,7 +561,7 @@ fn initializing_pool_slot_is_invisible_to_probe_lookup() {
     pool.lookup_probes(exec_id, 22, &mut probes);
 
     assert!(probes.is_empty());
-    assert_eq!(pool.refs_for_test(0), 1);
+    assert_eq!(pool.refs_for_test(0), 0);
 }
 
 #[test]

--- a/runtime/filter/src/tests.rs
+++ b/runtime/filter/src/tests.rs
@@ -2,6 +2,8 @@ use std::alloc::{alloc_zeroed, dealloc, Layout};
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use control_transport::{BackendLeaseId, BackendLeaseSlot};
+
 use super::*;
 
 fn bit_storage(words: usize) -> Vec<AtomicU64> {
@@ -34,6 +36,21 @@ fn pool_fixture(slot_count: u32) -> (RuntimeFilterPool, PoolMemory) {
     let pool = unsafe { RuntimeFilterPool::init_in_place(ptr.as_ptr(), pool_layout.size, config) }
         .expect("pool init");
     (pool, memory)
+}
+
+fn make_exec_id(slot_id: u32) -> RuntimeFilterExecId {
+    RuntimeFilterExecId::new(slot_id, 101, 202, 303)
+}
+
+#[test]
+fn exec_id_from_peer_uses_full_backend_lease_identity() {
+    let peer = BackendLeaseSlot::new(7, BackendLeaseId::new(11, 13));
+    let exec_id = RuntimeFilterExecId::from_peer(peer, 17);
+
+    assert_eq!(exec_id.slot_id(), 7);
+    assert_eq!(exec_id.generation(), 11);
+    assert_eq!(exec_id.lease_epoch(), 13);
+    assert_eq!(exec_id.session_epoch(), 17);
 }
 
 fn expect_builder_error(
@@ -495,8 +512,9 @@ fn raw_attach_accepts_valid_atomic_storage() {
 #[test]
 fn pool_publishes_filter_and_probe_rejects_absent_keys() {
     let (pool, _memory) = pool_fixture(1);
+    let exec_id = make_exec_id(11);
     let target = RuntimeFilterTarget {
-        session_epoch: 11,
+        exec_id,
         scan_id: 22,
         output_column: 3,
         key_type: RuntimeFilterKeyType::Int64,
@@ -509,7 +527,7 @@ fn pool_publishes_filter_and_probe_rejects_absent_keys() {
     build.publish_ready().unwrap();
 
     let mut probes = Vec::new();
-    pool.lookup_probes(11, 22, &mut probes);
+    pool.lookup_probes(exec_id, 22, &mut probes);
     assert_eq!(probes.len(), 1);
     assert_eq!(probes[0].output_column(), 3);
     assert_eq!(probes[0].key_type(), RuntimeFilterKeyType::Int64);
@@ -528,10 +546,31 @@ fn pool_publishes_filter_and_probe_rejects_absent_keys() {
 }
 
 #[test]
+fn initializing_pool_slot_is_invisible_to_probe_lookup() {
+    let (pool, _memory) = pool_fixture(1);
+    let exec_id = make_exec_id(11);
+    let target = RuntimeFilterTarget {
+        exec_id,
+        scan_id: 22,
+        output_column: 3,
+        key_type: RuntimeFilterKeyType::Int64,
+    };
+    pool.initialize_slot_for_test(0, target);
+
+    let mut probes = Vec::new();
+    pool.lookup_probes(exec_id, 22, &mut probes);
+
+    assert!(probes.is_empty());
+    assert_eq!(pool.refs_for_test(0), 1);
+}
+
+#[test]
 fn pool_does_not_reuse_storage_until_probes_are_dropped() {
     let (pool, _memory) = pool_fixture(1);
+    let first_exec_id = make_exec_id(1);
+    let next_exec_id = make_exec_id(3);
     let target = RuntimeFilterTarget {
-        session_epoch: 1,
+        exec_id: first_exec_id,
         scan_id: 2,
         output_column: 0,
         key_type: RuntimeFilterKeyType::Int32,
@@ -544,13 +583,13 @@ fn pool_does_not_reuse_storage_until_probes_are_dropped() {
     build.publish_ready().unwrap();
 
     let mut probes = Vec::new();
-    pool.lookup_probes(1, 2, &mut probes);
+    pool.lookup_probes(first_exec_id, 2, &mut probes);
     assert_eq!(probes.len(), 1);
     drop(build);
 
     let next = pool
         .allocate_build(RuntimeFilterTarget {
-            session_epoch: 3,
+            exec_id: next_exec_id,
             scan_id: 4,
             output_column: 0,
             key_type: RuntimeFilterKeyType::Int32,
@@ -561,11 +600,37 @@ fn pool_does_not_reuse_storage_until_probes_are_dropped() {
     drop(probes);
     assert!(pool
         .allocate_build(RuntimeFilterTarget {
-            session_epoch: 3,
+            exec_id: next_exec_id,
             scan_id: 4,
             output_column: 0,
             key_type: RuntimeFilterKeyType::Int32,
         })
         .expect("allocate after old probe exits")
         .is_some());
+}
+
+#[test]
+fn pool_namespaces_targets_by_execution_identity() {
+    let (pool, _memory) = pool_fixture(1);
+    let target_exec_id = RuntimeFilterExecId::new(1, 2, 3, 4);
+    let other_exec_id = RuntimeFilterExecId::new(1, 2, 5, 4);
+    let build = pool
+        .allocate_build(RuntimeFilterTarget {
+            exec_id: target_exec_id,
+            scan_id: 22,
+            output_column: 3,
+            key_type: RuntimeFilterKeyType::Int64,
+        })
+        .expect("allocate")
+        .expect("available slot");
+    build.insert_hash(hash_int_key(42)).unwrap();
+    build.publish_ready().unwrap();
+
+    let mut probes = Vec::new();
+    pool.lookup_probes(other_exec_id, 22, &mut probes);
+    assert!(probes.is_empty());
+
+    pool.lookup_probes(target_exec_id, 22, &mut probes);
+    assert_eq!(probes.len(), 1);
+    assert_eq!(probes[0].output_column(), 3);
 }

--- a/runtime/filter/tests/loom_lifecycle.rs
+++ b/runtime/filter/tests/loom_lifecycle.rs
@@ -7,6 +7,11 @@ const BUILDING: u64 = 1;
 const READY: u64 = 2;
 const DISABLED: u64 = 3;
 
+const POOL_FREE: u64 = 0;
+const POOL_INITIALIZING: u64 = 1;
+const POOL_ALLOCATED: u64 = 2;
+const POOL_RETIRING: u64 = 3;
+
 fn pack(generation: u64, state: u64) -> u64 {
     (generation << 2) | state
 }
@@ -90,6 +95,76 @@ impl ModelSlot {
         state(current) == READY
             && generation(current) == expected_generation
             && (self.bitset.load(Ordering::Relaxed) & 1) == 0
+    }
+}
+
+struct ModelPoolSlot {
+    state: AtomicU64,
+    refs: AtomicU64,
+    exec_id: AtomicU64,
+}
+
+impl ModelPoolSlot {
+    fn new() -> Self {
+        Self {
+            state: AtomicU64::new(POOL_FREE),
+            refs: AtomicU64::new(0),
+            exec_id: AtomicU64::new(0),
+        }
+    }
+
+    fn allocate_publish_and_release(&self) {
+        if self
+            .state
+            .compare_exchange(
+                POOL_FREE,
+                POOL_INITIALIZING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return;
+        }
+
+        thread::yield_now();
+        self.refs.store(1, Ordering::Release);
+        self.exec_id.store(1, Ordering::Release);
+        self.state.store(POOL_ALLOCATED, Ordering::Release);
+        thread::yield_now();
+        self.release_owner();
+    }
+
+    fn lookup_nonmatching_probe(&self) {
+        if self.state.load(Ordering::Acquire) != POOL_ALLOCATED {
+            return;
+        }
+
+        self.refs.fetch_add(1, Ordering::AcqRel);
+        let matches = self.state.load(Ordering::Acquire) == POOL_ALLOCATED
+            && self.exec_id.load(Ordering::Acquire) == 2;
+        if !matches {
+            self.release_ref();
+        }
+    }
+
+    fn release_owner(&self) {
+        let _ = self.state.compare_exchange(
+            POOL_ALLOCATED,
+            POOL_RETIRING,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+        self.release_ref();
+    }
+
+    fn release_ref(&self) {
+        let old_refs = self.refs.fetch_sub(1, Ordering::AcqRel);
+        assert!(old_refs > 0, "pool reference count underflowed");
+        if old_refs == 1 && self.state.load(Ordering::Acquire) == POOL_RETIRING {
+            self.exec_id.store(0, Ordering::Release);
+            self.state.store(POOL_FREE, Ordering::Release);
+        }
     }
 }
 
@@ -190,5 +265,32 @@ fn stale_disable_cannot_move_lifecycle_backward() {
 
         stale.join().expect("stale actor should join");
         observer.join().expect("observer should join");
+    });
+}
+
+#[test]
+fn pool_initializing_state_blocks_probe_refcount_race() {
+    loom::model(|| {
+        let slot = Arc::new(ModelPoolSlot::new());
+
+        let allocator = {
+            let slot = slot.clone();
+            thread::spawn(move || {
+                slot.allocate_publish_and_release();
+            })
+        };
+
+        let probe = {
+            let slot = slot.clone();
+            thread::spawn(move || {
+                slot.lookup_nonmatching_probe();
+            })
+        };
+
+        allocator.join().expect("allocator should join");
+        probe.join().expect("probe should join");
+
+        assert_eq!(slot.state.load(Ordering::Acquire), POOL_FREE);
+        assert_eq!(slot.refs.load(Ordering::Acquire), 0);
     });
 }

--- a/runtime/filter/tests/loom_lifecycle.rs
+++ b/runtime/filter/tests/loom_lifecycle.rs
@@ -11,6 +11,10 @@ const POOL_FREE: u64 = 0;
 const POOL_INITIALIZING: u64 = 1;
 const POOL_ALLOCATED: u64 = 2;
 const POOL_RETIRING: u64 = 3;
+const POOL_REF_BITS: u32 = 16;
+const POOL_REF_SHIFT: u32 = 2;
+const POOL_EPOCH_SHIFT: u32 = POOL_REF_SHIFT + POOL_REF_BITS;
+const POOL_REF_MASK: u64 = (1u64 << POOL_REF_BITS) - 1;
 
 fn pack(generation: u64, state: u64) -> u64 {
     (generation << 2) | state
@@ -22,6 +26,22 @@ fn generation(word: u64) -> u64 {
 
 fn state(word: u64) -> u64 {
     word & 3
+}
+
+fn pack_pool(state: u64, refs: u64, epoch: u64) -> u64 {
+    state | (refs << POOL_REF_SHIFT) | (epoch << POOL_EPOCH_SHIFT)
+}
+
+fn pool_state(word: u64) -> u64 {
+    word & 3
+}
+
+fn pool_refs(word: u64) -> u64 {
+    (word >> POOL_REF_SHIFT) & POOL_REF_MASK
+}
+
+fn pool_epoch(word: u64) -> u64 {
+    word >> POOL_EPOCH_SHIFT
 }
 
 struct ModelSlot {
@@ -99,72 +119,146 @@ impl ModelSlot {
 }
 
 struct ModelPoolSlot {
-    state: AtomicU64,
-    refs: AtomicU64,
+    meta: AtomicU64,
     exec_id: AtomicU64,
 }
 
 impl ModelPoolSlot {
     fn new() -> Self {
         Self {
-            state: AtomicU64::new(POOL_FREE),
-            refs: AtomicU64::new(0),
+            meta: AtomicU64::new(pack_pool(POOL_FREE, 0, 0)),
             exec_id: AtomicU64::new(0),
         }
     }
 
+    fn allocate(&self, exec_id: u64) -> bool {
+        let mut current = self.meta.load(Ordering::Acquire);
+        loop {
+            if pool_state(current) != POOL_FREE || pool_refs(current) != 0 {
+                return false;
+            }
+            let epoch = pool_epoch(current) + 1;
+            match self.meta.compare_exchange(
+                current,
+                pack_pool(POOL_INITIALIZING, 0, epoch),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    thread::yield_now();
+                    self.exec_id.store(exec_id, Ordering::Release);
+                    self.meta
+                        .store(pack_pool(POOL_ALLOCATED, 1, epoch), Ordering::Release);
+                    return true;
+                }
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
     fn allocate_publish_and_release(&self) {
-        if self
-            .state
+        if self.allocate(1) {
+            thread::yield_now();
+            self.release_owner();
+        }
+    }
+
+    fn acquire_probe_ref_from(&self, observed: u64) -> bool {
+        if pool_state(observed) != POOL_ALLOCATED {
+            return false;
+        }
+        let refs = pool_refs(observed);
+        if refs == POOL_REF_MASK {
+            return false;
+        }
+        self.meta
             .compare_exchange(
-                POOL_FREE,
-                POOL_INITIALIZING,
+                observed,
+                pack_pool(POOL_ALLOCATED, refs + 1, pool_epoch(observed)),
                 Ordering::AcqRel,
                 Ordering::Acquire,
             )
-            .is_err()
-        {
-            return;
-        }
-
-        thread::yield_now();
-        self.refs.store(1, Ordering::Release);
-        self.exec_id.store(1, Ordering::Release);
-        self.state.store(POOL_ALLOCATED, Ordering::Release);
-        thread::yield_now();
-        self.release_owner();
+            .is_ok()
     }
 
     fn lookup_nonmatching_probe(&self) {
-        if self.state.load(Ordering::Acquire) != POOL_ALLOCATED {
+        let observed = self.meta.load(Ordering::Acquire);
+        if self.acquire_probe_ref_from(observed) && self.exec_id.load(Ordering::Acquire) != 2 {
+            self.release_ref();
+        }
+    }
+
+    fn lookup_nonmatching_probe_after_observation_delay(&self) {
+        let observed = self.meta.load(Ordering::Acquire);
+        if pool_state(observed) != POOL_ALLOCATED {
             return;
         }
-
-        self.refs.fetch_add(1, Ordering::AcqRel);
-        let matches = self.state.load(Ordering::Acquire) == POOL_ALLOCATED
-            && self.exec_id.load(Ordering::Acquire) == 2;
-        if !matches {
+        thread::yield_now();
+        if self.acquire_probe_ref_from(observed) && self.exec_id.load(Ordering::Acquire) != 2 {
             self.release_ref();
         }
     }
 
     fn release_owner(&self) {
-        let _ = self.state.compare_exchange(
-            POOL_ALLOCATED,
-            POOL_RETIRING,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        );
-        self.release_ref();
+        let mut current = self.meta.load(Ordering::Acquire);
+        loop {
+            if pool_state(current) != POOL_ALLOCATED {
+                return;
+            }
+            let refs = pool_refs(current);
+            assert!(refs > 0, "owner ref is missing");
+            let epoch = pool_epoch(current);
+            let next_refs = refs - 1;
+            match self.meta.compare_exchange(
+                current,
+                pack_pool(POOL_RETIRING, next_refs, epoch),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    if next_refs == 0 {
+                        self.finish_retire(epoch);
+                    }
+                    return;
+                }
+                Err(actual) => current = actual,
+            }
+        }
     }
 
     fn release_ref(&self) {
-        let old_refs = self.refs.fetch_sub(1, Ordering::AcqRel);
-        assert!(old_refs > 0, "pool reference count underflowed");
-        if old_refs == 1 && self.state.load(Ordering::Acquire) == POOL_RETIRING {
-            self.exec_id.store(0, Ordering::Release);
-            self.state.store(POOL_FREE, Ordering::Release);
+        let mut current = self.meta.load(Ordering::Acquire);
+        loop {
+            let state = pool_state(current);
+            assert!(
+                state == POOL_ALLOCATED || state == POOL_RETIRING,
+                "ref released from inactive slot",
+            );
+            let refs = pool_refs(current);
+            assert!(refs > 0, "pool reference count underflowed");
+            let epoch = pool_epoch(current);
+            let next_refs = refs - 1;
+            match self.meta.compare_exchange(
+                current,
+                pack_pool(state, next_refs, epoch),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    if state == POOL_RETIRING && next_refs == 0 {
+                        self.finish_retire(epoch);
+                    }
+                    return;
+                }
+                Err(actual) => current = actual,
+            }
         }
+    }
+
+    fn finish_retire(&self, epoch: u64) {
+        self.exec_id.store(0, Ordering::Release);
+        self.meta
+            .store(pack_pool(POOL_FREE, 0, epoch), Ordering::Release);
     }
 }
 
@@ -290,7 +384,42 @@ fn pool_initializing_state_blocks_probe_refcount_race() {
         allocator.join().expect("allocator should join");
         probe.join().expect("probe should join");
 
-        assert_eq!(slot.state.load(Ordering::Acquire), POOL_FREE);
-        assert_eq!(slot.refs.load(Ordering::Acquire), 0);
+        let final_meta = slot.meta.load(Ordering::Acquire);
+        assert_eq!(pool_state(final_meta), POOL_FREE);
+        assert_eq!(pool_refs(final_meta), 0);
+    });
+}
+
+#[test]
+fn stale_observed_probe_cannot_mutate_reused_pool_slot() {
+    loom::model(|| {
+        let slot = Arc::new(ModelPoolSlot::new());
+        assert!(slot.allocate(1));
+
+        let stale_probe = {
+            let slot = slot.clone();
+            thread::spawn(move || {
+                slot.lookup_nonmatching_probe_after_observation_delay();
+            })
+        };
+
+        let recycler = {
+            let slot = slot.clone();
+            thread::spawn(move || {
+                thread::yield_now();
+                slot.release_owner();
+                let _ = slot.allocate(2);
+            })
+        };
+
+        stale_probe.join().expect("stale probe should join");
+        recycler.join().expect("recycler should join");
+
+        let final_meta = slot.meta.load(Ordering::Acquire);
+        match pool_state(final_meta) {
+            POOL_FREE => assert_eq!(pool_refs(final_meta), 0),
+            POOL_ALLOCATED => assert_eq!(pool_refs(final_meta), 1),
+            other => panic!("unexpected final pool state {other}"),
+        }
     });
 }

--- a/runtime/metrics/src/lib.rs
+++ b/runtime/metrics/src/lib.rs
@@ -956,7 +956,7 @@ fn validate_min_header(base: NonNull<u8>, len: usize) -> Result<(), MetricsError
 }
 
 fn validate_region(base: NonNull<u8>, len: usize, layout: Layout) -> Result<(), MetricsError> {
-    if (base.as_ptr() as usize) % layout.align() != 0 {
+    if !(base.as_ptr() as usize).is_multiple_of(layout.align()) {
         return Err(MetricsError::BadAlignment {
             expected: layout.align(),
             actual: base.as_ptr() as usize,
@@ -980,7 +980,7 @@ fn align_up(value: usize, align: usize) -> Result<usize, MetricsError> {
 }
 
 fn pack_epoch_direction(epoch: u64, direction: PageDirection) -> u64 {
-    epoch.checked_shl(8).unwrap_or(u64::MAX & !0xff) | direction as u64
+    epoch.checked_shl(8).unwrap_or(!0xff) | direction as u64
 }
 
 pub fn monotonic_ns() -> u64 {

--- a/runtime/protocol/src/codec.rs
+++ b/runtime/protocol/src/codec.rs
@@ -7,9 +7,11 @@
 
 use crate::envelope::{
     decode_runtime_header, expect_runtime_family, write_runtime_header_to,
-    BACKEND_EXECUTION_CANCEL_TAG, BACKEND_EXECUTION_FAIL_TAG, BACKEND_EXECUTION_START_TAG,
+    BACKEND_EXECUTION_CANCEL_RESERVATION_TAG, BACKEND_EXECUTION_CANCEL_TAG,
+    BACKEND_EXECUTION_FAIL_TAG, BACKEND_EXECUTION_RESERVE_SLOT_TAG, BACKEND_EXECUTION_START_TAG,
     BACKEND_SCAN_FAILED_TAG, BACKEND_SCAN_FINISHED_TAG, WORKER_EXECUTION_COMPLETE_TAG,
-    WORKER_EXECUTION_FAIL_TAG, WORKER_SCAN_CANCEL_TAG, WORKER_SCAN_OPEN_TAG,
+    WORKER_EXECUTION_FAIL_TAG, WORKER_EXECUTION_SLOT_RESERVED_TAG, WORKER_SCAN_CANCEL_TAG,
+    WORKER_SCAN_OPEN_TAG,
 };
 use crate::error::{DecodeError, EncodeError};
 use crate::message::{
@@ -119,9 +121,10 @@ pub fn decode_backend_execution_to_worker(
         RuntimeMessageFamily::BackendExecutionToWorker,
     )?;
 
-    let session_epoch = read_u64_from(&mut source)?;
     let message = match header.tag {
+        BACKEND_EXECUTION_RESERVE_SLOT_TAG => BackendExecutionToWorkerRef::ReserveExecutionSlot,
         BACKEND_EXECUTION_START_TAG => {
+            let session_epoch = read_u64_from(&mut source)?;
             let plan = PlanFlowDescriptor {
                 plan_id: read_u64_from(&mut source)?,
                 page_kind: read_u16_from(&mut source)?,
@@ -141,13 +144,20 @@ pub fn decode_backend_execution_to_worker(
             }
         }
         BACKEND_EXECUTION_CANCEL_TAG => {
+            let session_epoch = read_u64_from(&mut source)?;
             BackendExecutionToWorkerRef::CancelExecution { session_epoch }
         }
-        BACKEND_EXECUTION_FAIL_TAG => BackendExecutionToWorkerRef::FailExecution {
-            session_epoch,
-            code: ExecutionFailureCode::try_from(read_u8_from(&mut source)?)?,
-            detail: read_optional_u64_from(&mut source)?,
-        },
+        BACKEND_EXECUTION_CANCEL_RESERVATION_TAG => {
+            BackendExecutionToWorkerRef::CancelExecutionReservation
+        }
+        BACKEND_EXECUTION_FAIL_TAG => {
+            let session_epoch = read_u64_from(&mut source)?;
+            BackendExecutionToWorkerRef::FailExecution {
+                session_epoch,
+                code: ExecutionFailureCode::try_from(read_u8_from(&mut source)?)?,
+                detail: read_optional_u64_from(&mut source)?,
+            }
+        }
         actual => return Err(DecodeError::UnexpectedTag { actual }),
     };
 
@@ -167,16 +177,20 @@ pub fn decode_worker_execution_to_backend(
         RuntimeMessageFamily::WorkerExecutionToBackend,
     )?;
 
-    let session_epoch = read_u64_from(&mut source)?;
     let message = match header.tag {
+        WORKER_EXECUTION_SLOT_RESERVED_TAG => WorkerExecutionToBackend::ExecutionSlotReserved,
         WORKER_EXECUTION_COMPLETE_TAG => {
+            let session_epoch = read_u64_from(&mut source)?;
             WorkerExecutionToBackend::CompleteExecution { session_epoch }
         }
-        WORKER_EXECUTION_FAIL_TAG => WorkerExecutionToBackend::FailExecution {
-            session_epoch,
-            code: ExecutionFailureCode::try_from(read_u8_from(&mut source)?)?,
-            detail: read_optional_str_from(&mut source)?.map(ToOwned::to_owned),
-        },
+        WORKER_EXECUTION_FAIL_TAG => {
+            let session_epoch = read_u64_from(&mut source)?;
+            WorkerExecutionToBackend::FailExecution {
+                session_epoch,
+                code: ExecutionFailureCode::try_from(read_u8_from(&mut source)?)?,
+                detail: read_optional_str_from(&mut source)?.map(ToOwned::to_owned),
+            }
+        }
         actual => return Err(DecodeError::UnexpectedTag { actual }),
     };
 
@@ -277,6 +291,13 @@ fn encode_backend_execution_to_worker_to<W: std::io::Write>(
     sink: &mut W,
 ) -> Result<(), EncodeError> {
     match message {
+        BackendExecutionToWorker::ReserveExecutionSlot => {
+            write_runtime_header_to(
+                sink,
+                RuntimeMessageFamily::BackendExecutionToWorker,
+                BACKEND_EXECUTION_RESERVE_SLOT_TAG,
+            )?;
+        }
         BackendExecutionToWorker::StartExecution {
             session_epoch,
             plan,
@@ -305,6 +326,13 @@ fn encode_backend_execution_to_worker_to<W: std::io::Write>(
             )?;
             write_u64_to(sink, session_epoch)?;
         }
+        BackendExecutionToWorker::CancelExecutionReservation => {
+            write_runtime_header_to(
+                sink,
+                RuntimeMessageFamily::BackendExecutionToWorker,
+                BACKEND_EXECUTION_CANCEL_RESERVATION_TAG,
+            )?;
+        }
         BackendExecutionToWorker::FailExecution {
             session_epoch,
             code,
@@ -328,6 +356,13 @@ fn encode_worker_execution_to_backend_to<W: std::io::Write>(
     sink: &mut W,
 ) -> Result<(), EncodeError> {
     match message {
+        WorkerExecutionToBackend::ExecutionSlotReserved => {
+            write_runtime_header_to(
+                sink,
+                RuntimeMessageFamily::WorkerExecutionToBackend,
+                WORKER_EXECUTION_SLOT_RESERVED_TAG,
+            )?;
+        }
         WorkerExecutionToBackend::CompleteExecution { session_epoch } => {
             write_runtime_header_to(
                 sink,

--- a/runtime/protocol/src/envelope.rs
+++ b/runtime/protocol/src/envelope.rs
@@ -9,9 +9,12 @@ pub const RUNTIME_ENVELOPE_HEADER_LEN: usize = 8;
 pub(crate) const BACKEND_EXECUTION_START_TAG: u8 = 1;
 pub(crate) const BACKEND_EXECUTION_CANCEL_TAG: u8 = 2;
 pub(crate) const BACKEND_EXECUTION_FAIL_TAG: u8 = 3;
+pub(crate) const BACKEND_EXECUTION_RESERVE_SLOT_TAG: u8 = 4;
+pub(crate) const BACKEND_EXECUTION_CANCEL_RESERVATION_TAG: u8 = 5;
 
 pub(crate) const WORKER_EXECUTION_COMPLETE_TAG: u8 = 1;
 pub(crate) const WORKER_EXECUTION_FAIL_TAG: u8 = 2;
+pub(crate) const WORKER_EXECUTION_SLOT_RESERVED_TAG: u8 = 3;
 pub(crate) const WORKER_SCAN_OPEN_TAG: u8 = 1;
 pub(crate) const WORKER_SCAN_CANCEL_TAG: u8 = 2;
 pub(crate) const BACKEND_SCAN_FINISHED_TAG: u8 = 1;

--- a/runtime/protocol/src/lib.rs
+++ b/runtime/protocol/src/lib.rs
@@ -3,7 +3,8 @@
 //! `protocol` stays intentionally small:
 //!
 //! - one protocol payload fits into one `control_transport` frame
-//! - `session_epoch` is always explicit
+//! - execution messages that target a running session carry an explicit
+//!   `session_epoch`; pre-session admission messages do not
 //! - plan and scan page streams are referenced through narrow descriptor types
 //! - decode of scan producer descriptors is borrow-friendly and allocation-free
 //! - scan terminal signals use their own dedicated wire family
@@ -19,9 +20,9 @@
 //! - [`error`] for protocol encoding and decoding failures
 //!
 //! The crate does not own execution state or flow runtimes. Higher layers are
-//! responsible for classifying `session_epoch`, dropping stale traffic, and
-//! reconstructing concrete `plan_flow` / `scan_flow` descriptors from the
-//! values returned here.
+//! responsible for classifying `session_epoch`, dropping stale traffic,
+//! admitting pre-session execution reservations, and reconstructing concrete
+//! `plan_flow` / `scan_flow` descriptors from the values returned here.
 //!
 //! Typical control encode/decode stays available from the crate root:
 //!

--- a/runtime/protocol/src/message.rs
+++ b/runtime/protocol/src/message.rs
@@ -91,6 +91,8 @@ impl Default for ExecutionOptionsWire {
 /// Encode-side backend execution control messages carried on the primary slot.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BackendExecutionToWorker<'a> {
+    /// Reserve one worker execution slot before backend-side scan workers start.
+    ReserveExecutionSlot,
     /// Start one execution with its plan descriptor and published scan channels.
     StartExecution {
         session_epoch: u64,
@@ -98,6 +100,8 @@ pub enum BackendExecutionToWorker<'a> {
         options: ExecutionOptionsWire,
         scans: ScanChannelSet<'a>,
     },
+    /// Cancel a previously requested or granted execution reservation.
+    CancelExecutionReservation,
     /// Cancel one execution identified by `session_epoch`.
     CancelExecution { session_epoch: u64 },
     /// Fail one execution identified by `session_epoch`.
@@ -110,11 +114,12 @@ pub enum BackendExecutionToWorker<'a> {
 
 impl BackendExecutionToWorker<'_> {
     /// Return the `session_epoch` targeted by this message.
-    pub fn session_epoch(self) -> u64 {
+    pub fn session_epoch(self) -> Option<u64> {
         match self {
             Self::StartExecution { session_epoch, .. }
             | Self::CancelExecution { session_epoch }
-            | Self::FailExecution { session_epoch, .. } => session_epoch,
+            | Self::FailExecution { session_epoch, .. } => Some(session_epoch),
+            Self::ReserveExecutionSlot | Self::CancelExecutionReservation => None,
         }
     }
 }
@@ -122,6 +127,8 @@ impl BackendExecutionToWorker<'_> {
 /// Decode-side borrowed backend execution control messages.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BackendExecutionToWorkerRef<'a> {
+    /// Borrowed reservation request.
+    ReserveExecutionSlot,
     /// Borrowed `StartExecution` view with validated borrowed scan-channel set.
     StartExecution {
         session_epoch: u64,
@@ -129,6 +136,8 @@ pub enum BackendExecutionToWorkerRef<'a> {
         options: ExecutionOptionsWire,
         scans: ScanChannelSetRef<'a>,
     },
+    /// Borrowed reservation cancellation.
+    CancelExecutionReservation,
     /// Borrowed `CancelExecution` view.
     CancelExecution { session_epoch: u64 },
     /// Borrowed `FailExecution` view.
@@ -141,11 +150,12 @@ pub enum BackendExecutionToWorkerRef<'a> {
 
 impl BackendExecutionToWorkerRef<'_> {
     /// Return the `session_epoch` targeted by this message.
-    pub fn session_epoch(self) -> u64 {
+    pub fn session_epoch(self) -> Option<u64> {
         match self {
             Self::StartExecution { session_epoch, .. }
             | Self::CancelExecution { session_epoch }
-            | Self::FailExecution { session_epoch, .. } => session_epoch,
+            | Self::FailExecution { session_epoch, .. } => Some(session_epoch),
+            Self::ReserveExecutionSlot | Self::CancelExecutionReservation => None,
         }
     }
 }
@@ -153,6 +163,8 @@ impl BackendExecutionToWorkerRef<'_> {
 /// Execution-level worker-to-backend control sent only on the primary slot.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum WorkerExecutionToBackend {
+    /// Grant a previously requested execution slot reservation.
+    ExecutionSlotReserved,
     /// Mark one execution as complete.
     CompleteExecution { session_epoch: u64 },
     /// Mark one execution as failed.
@@ -165,10 +177,11 @@ pub enum WorkerExecutionToBackend {
 
 impl WorkerExecutionToBackend {
     /// Return the `session_epoch` targeted by this message.
-    pub fn session_epoch(&self) -> u64 {
+    pub fn session_epoch(&self) -> Option<u64> {
         match self {
             Self::CompleteExecution { session_epoch }
-            | Self::FailExecution { session_epoch, .. } => *session_epoch,
+            | Self::FailExecution { session_epoch, .. } => Some(*session_epoch),
+            Self::ExecutionSlotReserved => None,
         }
     }
 }

--- a/runtime/protocol/src/tests.rs
+++ b/runtime/protocol/src/tests.rs
@@ -263,6 +263,25 @@ fn classify_session_orders_epochs() {
 }
 
 #[test]
+fn backend_execution_reservation_round_trips() {
+    let encoded = encode_backend(BackendExecutionToWorker::ReserveExecutionSlot);
+    let decoded = decode_backend_execution_to_worker(&encoded).expect("decode");
+    assert_eq!(decoded, BackendExecutionToWorkerRef::ReserveExecutionSlot);
+    assert_eq!(decoded.session_epoch(), None);
+}
+
+#[test]
+fn backend_execution_reservation_cancel_round_trips() {
+    let encoded = encode_backend(BackendExecutionToWorker::CancelExecutionReservation);
+    let decoded = decode_backend_execution_to_worker(&encoded).expect("decode");
+    assert_eq!(
+        decoded,
+        BackendExecutionToWorkerRef::CancelExecutionReservation
+    );
+    assert_eq!(decoded.session_epoch(), None);
+}
+
+#[test]
 fn backend_start_execution_round_trips_with_empty_scan_map() {
     let message = BackendExecutionToWorker::StartExecution {
         session_epoch: 9,
@@ -281,6 +300,7 @@ fn backend_start_execution_round_trips_with_empty_scan_map() {
             scans: ScanChannelSetRef::empty(),
         }
     );
+    assert_eq!(decoded.session_epoch(), Some(9));
 }
 
 #[test]
@@ -622,6 +642,14 @@ fn backend_scan_failed_rejects_message_over_bounded_len() {
             maximum: MAX_SCAN_FAILURE_MESSAGE_LEN,
         }
     );
+}
+
+#[test]
+fn worker_execution_slot_reserved_round_trips() {
+    let encoded = encode_worker_execution(WorkerExecutionToBackend::ExecutionSlotReserved);
+    let decoded = decode_worker_execution_to_backend(&encoded).expect("decode");
+    assert_eq!(decoded, WorkerExecutionToBackend::ExecutionSlotReserved);
+    assert_eq!(decoded.session_epoch(), None);
 }
 
 #[test]

--- a/runtime/worker/src/runtime.rs
+++ b/runtime/worker/src/runtime.rs
@@ -36,7 +36,7 @@ use crate::spill::WorkerSpillConfig;
 /// Static configuration for one worker-side runtime instance.
 #[derive(Clone, Debug)]
 pub struct WorkerRuntimeConfig {
-    /// Maximum single control frame payload read from `control_transport`.
+    /// Scratch capacity for one primary control frame payload, inbound or outbound.
     pub control_frame_capacity: usize,
     /// Page kind expected for backend scan result pages.
     pub scan_page_kind: transfer::MessageKind,
@@ -206,6 +206,11 @@ impl WorkerRuntimeCore {
         self.active_peer
     }
 
+    /// Peer key retained for stale-control classification after cleanup.
+    pub fn retained_peer(&self) -> Option<BackendLeaseSlot> {
+        self.latest_session.map(|session| session.peer)
+    }
+
     /// Borrow the currently prepared physical plan, if planning reached `Running`.
     pub fn physical_plan(&self) -> Option<Arc<dyn ExecutionPlan>> {
         self.physical_plan.as_ref().map(Arc::clone)
@@ -259,6 +264,13 @@ impl WorkerRuntimeCore {
         message: BackendToWorkerRef<'_>,
     ) -> Result<WorkerRuntimeStep, WorkerRuntimeError> {
         match message {
+            BackendToWorkerRef::ReserveExecutionSlot
+            | BackendToWorkerRef::CancelExecutionReservation => {
+                Err(WorkerRuntimeError::ProtocolViolation(
+                    "execution slot reservation messages must be handled by the worker scheduler"
+                        .into(),
+                ))
+            }
             BackendToWorkerRef::StartExecution {
                 session_epoch,
                 plan,
@@ -324,31 +336,56 @@ impl WorkerRuntimeCore {
         flow: PlanFlowId,
         result: Result<Arc<dyn ExecutionPlan>, WorkerRuntimeError>,
     ) -> Result<WorkerRuntimeStep, WorkerRuntimeError> {
+        let (step, planning_err) = self.finish_physical_planning_step(peer, flow, result)?;
+        if let Some(err) = planning_err {
+            Err(err)
+        } else {
+            Ok(step)
+        }
+    }
+
+    /// Commit one physical planning result and return a runtime step.
+    ///
+    /// Planning-stage failures are converted into an `ExecutionFailed` step and
+    /// returned with the original error so the scheduler can report that error
+    /// to the owning backend without treating it as a worker-global failure.
+    pub fn finish_physical_planning_step(
+        &mut self,
+        peer: BackendLeaseSlot,
+        flow: PlanFlowId,
+        result: Result<Arc<dyn ExecutionPlan>, WorkerRuntimeError>,
+    ) -> Result<(WorkerRuntimeStep, Option<WorkerRuntimeError>), WorkerRuntimeError> {
         if !self.matches_active_planning(peer, flow) {
-            return Ok(WorkerRuntimeStep::PlanningResultIgnored {
-                session_epoch: flow.session_epoch,
-                plan_id: flow.plan_id,
-            });
+            return Ok((
+                WorkerRuntimeStep::PlanningResultIgnored {
+                    session_epoch: flow.session_epoch,
+                    plan_id: flow.plan_id,
+                },
+                None,
+            ));
         }
 
         let physical_plan = match result {
             Ok(physical_plan) => physical_plan,
-            Err(err) => return Err(self.fail_planning_stage(err)),
+            Err(err) => return self.fail_planning_stage_step(err),
         };
 
         if let Err(err) = self.plan_role.close() {
-            return Err(self.fail_planning_stage(err.into()));
+            return self.fail_planning_stage_step(err.into());
         }
 
         if let Err(err) = self.consume_event(WorkerExecutionEvent::PhysicalPlanReady) {
-            return Err(self.fail_planning_stage(err));
+            return self.fail_planning_stage_step(err);
         }
 
         self.physical_plan = Some(Arc::clone(&physical_plan));
-        Ok(WorkerRuntimeStep::PhysicalPlanReady(PhysicalPlanResult {
-            session_epoch: flow.session_epoch,
-            plan: physical_plan,
-        }))
+        Ok((
+            WorkerRuntimeStep::PhysicalPlanReady(PhysicalPlanResult {
+                session_epoch: flow.session_epoch,
+                plan: physical_plan,
+            }),
+            None,
+        ))
     }
 
     /// Mark the active execution complete after the physical plan finished.
@@ -462,18 +499,18 @@ impl WorkerRuntimeCore {
         }
     }
 
-    fn fail_planning_stage(&mut self, err: WorkerRuntimeError) -> WorkerRuntimeError {
+    fn fail_planning_stage_step(
+        &mut self,
+        err: WorkerRuntimeError,
+    ) -> Result<(WorkerRuntimeStep, Option<WorkerRuntimeError>), WorkerRuntimeError> {
         self.plan_role.abort();
         self.physical_plan = None;
-        match self.consume_event(WorkerExecutionEvent::FailExecution) {
-            Ok(()) => {
-                self.clear_active_execution_state();
-                err
-            }
-            Err(terminal_err) => WorkerRuntimeError::StateMachine(format!(
+        match self.fail_execution_locally(ExecutionFailureCode::Internal, None) {
+            Ok(step) => Ok((step, Some(err))),
+            Err(terminal_err) => Err(WorkerRuntimeError::StateMachine(format!(
                 "planning failed: {}; failed to transition worker runtime to Terminal: {}",
                 err, terminal_err
-            )),
+            ))),
         }
     }
 
@@ -1414,6 +1451,7 @@ mod tests {
         ));
         assert_eq!(core.state(), WorkerExecutionState::Terminal);
         assert_eq!(core.session_epoch(), None);
+        assert_eq!(core.retained_peer(), Some(peer_a()));
 
         core.cleanup().unwrap();
         assert_eq!(core.state(), WorkerExecutionState::Idle);
@@ -1589,6 +1627,7 @@ mod tests {
         ));
         assert_eq!(core.state(), WorkerExecutionState::Idle);
         assert_eq!(core.session_epoch(), None);
+        assert_eq!(core.retained_peer(), Some(peer_a()));
     }
 
     #[test]
@@ -1634,6 +1673,7 @@ mod tests {
         ));
         assert_eq!(core.state(), WorkerExecutionState::Idle);
         assert_eq!(core.session_epoch(), None);
+        assert_eq!(core.retained_peer(), Some(peer_a()));
     }
 
     #[test]
@@ -2005,6 +2045,49 @@ mod tests {
                 plan_id: 21
             }
         ));
+    }
+
+    #[test]
+    fn physical_planning_failure_step_returns_execution_failed_step() {
+        let mut core = core();
+        accept(
+            &mut core,
+            BackendToWorker::StartExecution {
+                session_epoch: 10,
+                plan: plan_descriptor(20),
+                options: protocol::ExecutionOptionsWire::default(),
+                scans: ScanChannelSet::empty(),
+            },
+        )
+        .unwrap();
+        let flow = core.active_plan_flow.expect("active flow");
+        core.consume_event(WorkerExecutionEvent::PlanDecoded)
+            .unwrap();
+
+        let pending = core.begin_physical_planning(flow, unsupported_plan());
+        let peer = pending.peer();
+        let (step, planning_err) = core
+            .finish_physical_planning_step(peer, flow, block_on(pending.plan()))
+            .unwrap();
+
+        assert!(matches!(
+            planning_err,
+            Some(WorkerRuntimeError::DataFusion(_))
+        ));
+        assert!(matches!(
+            step,
+            WorkerRuntimeStep::ExecutionFailed {
+                session_epoch: 10,
+                code: ExecutionFailureCode::Internal,
+                detail: None
+            }
+        ));
+        assert_eq!(core.state(), WorkerExecutionState::Terminal);
+        assert_eq!(core.session_epoch(), None);
+        assert!(core.physical_plan().is_none());
+
+        core.cleanup().unwrap();
+        assert_eq!(core.state(), WorkerExecutionState::Idle);
     }
 
     #[test]

--- a/runtime/worker/src/runtime.rs
+++ b/runtime/worker/src/runtime.rs
@@ -12,7 +12,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use datafusion_expr::logical_plan::LogicalPlan;
 use datafusion_expr::registry::FunctionRegistry;
-use filter::RuntimeFilterPool;
+use filter::{RuntimeFilterExecId, RuntimeFilterPool};
 use issuance::{decode_issued_frame, IssuedOwnedFrame, IssuedRx};
 use metrics::RuntimeMetrics;
 use plan_flow::{FlowId as PlanFlowId, PlanOpen, WorkerPlanRole, WorkerStep as WorkerPlanStep};
@@ -719,7 +719,7 @@ impl PendingPhysicalPlanning {
             if self.runtime_filter_enabled && self.config.runtime_filter_pool.is_attached() {
                 install_runtime_filters(
                     physical_plan,
-                    self.flow.session_epoch,
+                    runtime_filter_exec_id(self.peer, self.flow.session_epoch),
                     self.config.runtime_filter_pool,
                     self.config.metrics,
                 )?
@@ -731,6 +731,10 @@ impl PendingPhysicalPlanning {
             &|plan| plan.as_any().is::<WorkerPgScanExec>(),
         )?)
     }
+}
+
+fn runtime_filter_exec_id(peer: BackendLeaseSlot, session_epoch: u64) -> RuntimeFilterExecId {
+    RuntimeFilterExecId::from_peer(peer, session_epoch)
 }
 
 fn materialize_scan_peer_map(

--- a/runtime/worker/src/runtime_filter_plan.rs
+++ b/runtime/worker/src/runtime_filter_plan.rs
@@ -23,8 +23,8 @@ use datafusion_expr::JoinType;
 use datafusion_physical_expr::expressions::Column;
 use filter::{
     hash_bool_key, hash_bytes_key, hash_decimal128_key, hash_float32_key, hash_float64_key,
-    hash_int_key, hash_interval_month_day_nano_key, RuntimeFilterBuildHandle, RuntimeFilterKeyType,
-    RuntimeFilterPool, RuntimeFilterTarget,
+    hash_int_key, hash_interval_month_day_nano_key, RuntimeFilterBuildHandle, RuntimeFilterExecId,
+    RuntimeFilterKeyType, RuntimeFilterPool, RuntimeFilterTarget,
 };
 use futures::{ready, Stream, StreamExt};
 use metrics::{MetricId, RuntimeMetrics};
@@ -33,14 +33,14 @@ use crate::scan_exec::WorkerPgScanExec;
 
 pub(crate) fn install_runtime_filters(
     plan: Arc<dyn ExecutionPlan>,
-    session_epoch: u64,
+    exec_id: RuntimeFilterExecId,
     pool: RuntimeFilterPool,
     metrics: RuntimeMetrics,
 ) -> DFResult<Arc<dyn ExecutionPlan>> {
     let children = plan.children();
     let rewritten_children = children
         .into_iter()
-        .map(|child| install_runtime_filters(Arc::clone(child), session_epoch, pool, metrics))
+        .map(|child| install_runtime_filters(Arc::clone(child), exec_id, pool, metrics))
         .collect::<DFResult<Vec<_>>>()?;
     let plan = if rewritten_children.is_empty() {
         plan
@@ -51,12 +51,12 @@ pub(crate) fn install_runtime_filters(
     let Some(join) = plan.as_any().downcast_ref::<HashJoinExec>() else {
         return Ok(plan);
     };
-    maybe_wrap_hash_join(join, session_epoch, pool, metrics).map(|wrapped| wrapped.unwrap_or(plan))
+    maybe_wrap_hash_join(join, exec_id, pool, metrics).map(|wrapped| wrapped.unwrap_or(plan))
 }
 
 fn maybe_wrap_hash_join(
     join: &HashJoinExec,
-    session_epoch: u64,
+    exec_id: RuntimeFilterExecId,
     pool: RuntimeFilterPool,
     metrics: RuntimeMetrics,
 ) -> DFResult<Option<Arc<dyn ExecutionPlan>>> {
@@ -89,7 +89,7 @@ fn maybe_wrap_hash_join(
     };
 
     let target = RuntimeFilterTarget {
-        session_epoch,
+        exec_id,
         scan_id: right_scan.scan_id().get(),
         output_column: right_col.index() as u32,
         key_type,
@@ -607,7 +607,10 @@ mod tests {
 
     use arrow_array::ArrayRef;
     use arrow_schema::{Field, Schema};
-    use filter::{BloomParams, ProbeDecision, RuntimeFilterPoolConfig, RuntimeFilterTarget};
+    use filter::{
+        BloomParams, ProbeDecision, RuntimeFilterExecId, RuntimeFilterPoolConfig,
+        RuntimeFilterTarget,
+    };
 
     struct PoolMemory {
         ptr: NonNull<u8>,
@@ -633,6 +636,10 @@ mod tests {
         (pool, memory)
     }
 
+    fn make_exec_id() -> RuntimeFilterExecId {
+        RuntimeFilterExecId::new(1, 2, 3, 4)
+    }
+
     fn build_and_probe(
         key_type: RuntimeFilterKeyType,
         data_type: DataType,
@@ -640,8 +647,9 @@ mod tests {
         present_hash: u64,
     ) {
         let (pool, _memory) = pool_fixture(1);
+        let exec_id = make_exec_id();
         let target = RuntimeFilterTarget {
-            session_epoch: 1,
+            exec_id,
             scan_id: 2,
             output_column: 0,
             key_type,
@@ -665,7 +673,7 @@ mod tests {
         state.publish_ready().expect("publish");
 
         let mut probes = Vec::new();
-        pool.lookup_probes(1, 2, &mut probes);
+        pool.lookup_probes(exec_id, 2, &mut probes);
         assert_eq!(probes.len(), 1);
         assert_eq!(
             probes[0].decision_for_hash(present_hash),

--- a/runtime/worker/src/spill.rs
+++ b/runtime/worker/src/spill.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use control_transport::BackendLeaseSlot;
 use datafusion_execution::{
     disk_manager::{DiskManagerBuilder, DiskManagerMode},
-    memory_pool::FairSpillPool,
+    memory_pool::{FairSpillPool, MemoryPool},
     runtime_env::RuntimeEnvBuilder,
     TaskContext,
 };
@@ -58,6 +58,7 @@ impl Default for WorkerSpillConfig {
 pub struct WorkerSpillRuntime {
     config: WorkerSpillConfig,
     active_dir: Option<PathBuf>,
+    memory_pool: Option<Arc<dyn MemoryPool>>,
     next_execution_serial: u64,
 }
 
@@ -71,10 +72,15 @@ impl WorkerSpillRuntime {
             return Ok(Self {
                 config,
                 active_dir: None,
+                memory_pool: None,
                 next_execution_serial: 0,
             });
         }
 
+        let memory_limit_bytes = config
+            .memory_limit_bytes
+            .expect("enabled worker spill must have a memory limit");
+        let memory_pool = Arc::new(FairSpillPool::new(memory_limit_bytes));
         create_dir_all(&config.root, "create spill root")?;
         let active_dir = config
             .root
@@ -86,6 +92,7 @@ impl WorkerSpillRuntime {
         Ok(Self {
             config,
             active_dir: Some(active_dir),
+            memory_pool: Some(memory_pool),
             next_execution_serial: 0,
         })
     }
@@ -124,7 +131,7 @@ impl WorkerSpillRuntime {
         &self,
         spill_dir: &ExecutionSpillDir,
     ) -> Result<Arc<TaskContext>, WorkerRuntimeError> {
-        let Some(memory_limit_bytes) = self.config.memory_limit_bytes else {
+        let Some(memory_pool) = &self.memory_pool else {
             return Ok(Arc::new(TaskContext::default()));
         };
         let spill_path = spill_dir.path().ok_or_else(|| {
@@ -133,7 +140,7 @@ impl WorkerSpillRuntime {
             )
         })?;
         let runtime = RuntimeEnvBuilder::new()
-            .with_memory_pool(Arc::new(FairSpillPool::new(memory_limit_bytes)))
+            .with_memory_pool(Arc::clone(memory_pool))
             .with_disk_manager_builder(
                 DiskManagerBuilder::default()
                     .with_mode(DiskManagerMode::Directories(vec![spill_path.to_path_buf()])),
@@ -322,6 +329,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use control_transport::BackendLeaseId;
+    use datafusion_execution::memory_pool::MemoryConsumer;
 
     use super::*;
 
@@ -475,6 +483,42 @@ mod tests {
 
         drop(file);
         dir.cleanup().unwrap();
+        drop(runtime);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn task_contexts_share_worker_memory_pool() {
+        let root = unique_root("shared_pool");
+        let config = WorkerSpillConfig::new(Some(1000), Some(root.clone()));
+        let mut runtime = WorkerSpillRuntime::new(config, 6, 9).unwrap();
+        let first_peer = BackendLeaseSlot::new(4, BackendLeaseId::new(10, 11));
+        let second_peer = BackendLeaseSlot::new(5, BackendLeaseId::new(10, 12));
+        let first_dir = runtime.execution_dir(first_peer, 12).unwrap();
+        let second_dir = runtime.execution_dir(second_peer, 13).unwrap();
+        let first_ctx = runtime.task_context(&first_dir).unwrap();
+        let second_ctx = runtime.task_context(&second_dir).unwrap();
+        let first_pool = first_ctx.runtime_env().memory_pool.clone();
+        let second_pool = second_ctx.runtime_env().memory_pool.clone();
+
+        let first_reservation = MemoryConsumer::new("first").register(&first_pool);
+        first_reservation.try_resize(700).unwrap();
+        assert_eq!(first_pool.reserved(), 700);
+        assert_eq!(second_pool.reserved(), 700);
+
+        let second_reservation = MemoryConsumer::new("second").register(&second_pool);
+        assert!(second_reservation.try_resize(400).is_err());
+        second_reservation.try_resize(300).unwrap();
+        assert_eq!(first_pool.reserved(), 1000);
+        assert_eq!(second_pool.reserved(), 1000);
+
+        drop(second_reservation);
+        drop(first_reservation);
+        assert_eq!(first_pool.reserved(), 0);
+        assert_eq!(second_pool.reserved(), 0);
+
+        first_dir.cleanup().unwrap();
+        second_dir.cleanup().unwrap();
         drop(runtime);
         let _ = std::fs::remove_dir_all(root);
     }


### PR DESCRIPTION
The old worker runtime could execute only one backend query at a time. That did not make sense for production: independent backend queries should not block each other inside the worker. There was no strong design reason for this limitation; we simply had not tested or hardened parallel execution before.

This could not be fixed by only switching to a multi-threaded Tokio runtime. Once multiple executions run at the same time, several hidden assumptions break: execution admission needs to be ordered and bounded, stale control messages can arrive after a slot is reused, terminal responses can fail when the control ring is full, runtime filters must not be shared across different backend executions, spill memory must be shared safely across tasks, and worker-side error reporting must fit the actual transport buffers.

This PR changes backend executions into scheduled worker tasks and adds the lifecycle machinery needed to run them safely in parallel. The worker now reserves execution capacity before starting work, keeps stale execution state long enough to handle late messages, retries terminal responses when needed, and treats per-query failures as query failures instead of worker failures.

It also fixes the shared runtime pieces that parallel execution depends on. Runtime filters are now namespaced by backend lease and session identity, with `RuntimeFilterExecId::from_peer` used by both backend and worker code. Filter pool slots are hidden while they are still being initialized, so concurrent probes cannot observe partial state. Spill memory is shared across execution tasks, and worker scratch buffers are sized so controlled failure responses can be sent reliably.

Closes #35 
